### PR TITLE
delivery 애그리거트 적용 

### DIFF
--- a/delivery/build.gradle
+++ b/delivery/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/delivery/src/main/java/com/example/delivery/DeliveryApplication.java
+++ b/delivery/src/main/java/com/example/delivery/DeliveryApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class DeliveryApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(DeliveryApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(DeliveryApplication.class, args);
+	}
 
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/CompanyDeliveryHistory.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/CompanyDeliveryHistory.java
@@ -1,9 +1,12 @@
 package com.example.delivery.domain.model.entity;
 
+import java.util.UUID;
+
 import com.example.delivery.domain.model.vo.Address;
 import com.example.delivery.domain.model.vo.DistanceAndDuration;
 import com.example.delivery.libs.exception.CustomException;
 import com.example.delivery.libs.exception.ErrorCode;
+
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -19,8 +22,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,70 +29,70 @@ import java.util.UUID;
 @Table(name = "p_company_delivery_history")
 public class CompanyDeliveryHistory {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID deliveryHistoryId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID deliveryHistoryId;
 
-    @Embedded
-    private Address address;
+	@Embedded
+	private Address address;
 
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "distance", column = @Column(name = "expected_distance", nullable = false)),
-            @AttributeOverride(name = "duration", column = @Column(name = "expected_duration", nullable = false))
-    })
-    private DistanceAndDuration expectedDistanceAndDuration;
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "distance", column = @Column(name = "expected_distance", nullable = false)),
+		@AttributeOverride(name = "duration", column = @Column(name = "expected_duration", nullable = false))
+	})
+	private DistanceAndDuration expectedDistanceAndDuration;
 
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "distance", column = @Column(name = "distance", nullable = false)),
-            @AttributeOverride(name = "duration", column = @Column(name = "duration", nullable = false))
-    })
-    private DistanceAndDuration distanceAndDuration;
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "distance", column = @Column(name = "distance", nullable = false)),
+		@AttributeOverride(name = "duration", column = @Column(name = "duration", nullable = false))
+	})
+	private DistanceAndDuration distanceAndDuration;
 
-    @Column(nullable = false)
-    private boolean isDeleted = false;
+	@Column(nullable = false)
+	private boolean isDeleted = false;
 
-    @Column(nullable = false)
-    private UUID deliveryStaffId;
+	@Column(nullable = false)
+	private UUID deliveryStaffId;
 
-    @Builder
-    private CompanyDeliveryHistory(Address address, DistanceAndDuration expectedDistanceAndDuration,
-                                  DistanceAndDuration distanceAndDuration, UUID deliveryStaffId) {
-        this.address = address;
-        this.expectedDistanceAndDuration = expectedDistanceAndDuration;
-        this.distanceAndDuration = distanceAndDuration;
-        this.deliveryStaffId = deliveryStaffId;
-    }
+	@Builder
+	private CompanyDeliveryHistory(Address address, DistanceAndDuration expectedDistanceAndDuration,
+		DistanceAndDuration distanceAndDuration, UUID deliveryStaffId) {
+		this.address = address;
+		this.expectedDistanceAndDuration = expectedDistanceAndDuration;
+		this.distanceAndDuration = distanceAndDuration;
+		this.deliveryStaffId = deliveryStaffId;
+	}
 
-    public static CompanyDeliveryHistory of(Address address, DistanceAndDuration expectedDistanceAndDuration,
-                                            DistanceAndDuration distanceAndDuration, UUID deliveryStaffId) {
+	public static CompanyDeliveryHistory of(Address address, DistanceAndDuration expectedDistanceAndDuration,
+		DistanceAndDuration distanceAndDuration, UUID deliveryStaffId) {
 
-        validateParam(expectedDistanceAndDuration, distanceAndDuration, deliveryStaffId);
+		validateParam(expectedDistanceAndDuration, distanceAndDuration, deliveryStaffId);
 
-        return CompanyDeliveryHistory.builder()
-                .address(address)
-                .expectedDistanceAndDuration(expectedDistanceAndDuration)
-                .distanceAndDuration(distanceAndDuration)
-                .deliveryStaffId(deliveryStaffId)
-                .build();
-    }
+		return CompanyDeliveryHistory.builder()
+			.address(address)
+			.expectedDistanceAndDuration(expectedDistanceAndDuration)
+			.distanceAndDuration(distanceAndDuration)
+			.deliveryStaffId(deliveryStaffId)
+			.build();
+	}
 
-    private static void validateParam(DistanceAndDuration expectedDistanceAndDuration,
-                                      DistanceAndDuration distanceAndDuration,
-                                      UUID deliveryStaffId) {
-        if (expectedDistanceAndDuration == null) {
-            throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
-        }
-        if (distanceAndDuration == null) {
-            throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
-        }
-        if (deliveryStaffId == null) {
-            throw new CustomException(ErrorCode.INVALID_DELIVERY_STAFF_EMPTY_OR_NULL);
-        }
-    }
+	private static void validateParam(DistanceAndDuration expectedDistanceAndDuration,
+		DistanceAndDuration distanceAndDuration,
+		UUID deliveryStaffId) {
+		if (expectedDistanceAndDuration == null) {
+			throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+		}
+		if (distanceAndDuration == null) {
+			throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+		}
+		if (deliveryStaffId == null) {
+			throw new CustomException(ErrorCode.INVALID_DELIVERY_STAFF_EMPTY_OR_NULL);
+		}
+	}
 
-    public void setDeleted(String username) {
-        this.isDeleted = true;
-    }
+	public void setDeleted(String username) {
+		this.isDeleted = true;
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/CompanyDeliveryHistory.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/CompanyDeliveryHistory.java
@@ -2,6 +2,8 @@ package com.example.delivery.domain.model.entity;
 
 import com.example.delivery.domain.model.vo.Address;
 import com.example.delivery.domain.model.vo.DistanceAndDuration;
+import com.example.delivery.libs.exception.CustomException;
+import com.example.delivery.libs.exception.ErrorCode;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -10,8 +12,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,8 +23,8 @@ import java.util.UUID;
 
 @Entity
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "p_company_delivery_history")
 public class CompanyDeliveryHistory {
 
@@ -53,21 +55,43 @@ public class CompanyDeliveryHistory {
     @Column(nullable = false)
     private UUID deliveryStaffId;
 
-    @OneToOne(mappedBy = "companyDeliveryHistory")
-    private Delivery delivery;
-
     @Builder
-    public CompanyDeliveryHistory(Address address, DistanceAndDuration expectedDistanceAndDuration,
-                                  DistanceAndDuration distanceAndDuration, UUID deliveryStaffId,
-                                  Delivery delivery) {
+    private CompanyDeliveryHistory(Address address, DistanceAndDuration expectedDistanceAndDuration,
+                                  DistanceAndDuration distanceAndDuration, UUID deliveryStaffId) {
         this.address = address;
         this.expectedDistanceAndDuration = expectedDistanceAndDuration;
         this.distanceAndDuration = distanceAndDuration;
         this.deliveryStaffId = deliveryStaffId;
-        this.delivery = delivery;
     }
 
-    public void setDeleted() {
+    public static CompanyDeliveryHistory of(Address address, DistanceAndDuration expectedDistanceAndDuration,
+                                            DistanceAndDuration distanceAndDuration, UUID deliveryStaffId) {
+
+        validateParam(expectedDistanceAndDuration, distanceAndDuration, deliveryStaffId);
+
+        return CompanyDeliveryHistory.builder()
+                .address(address)
+                .expectedDistanceAndDuration(expectedDistanceAndDuration)
+                .distanceAndDuration(distanceAndDuration)
+                .deliveryStaffId(deliveryStaffId)
+                .build();
+    }
+
+    private static void validateParam(DistanceAndDuration expectedDistanceAndDuration,
+                                      DistanceAndDuration distanceAndDuration,
+                                      UUID deliveryStaffId) {
+        if (expectedDistanceAndDuration == null) {
+            throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+        }
+        if (distanceAndDuration == null) {
+            throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+        }
+        if (deliveryStaffId == null) {
+            throw new CustomException(ErrorCode.INVALID_DELIVERY_STAFF_EMPTY_OR_NULL);
+        }
+    }
+
+    public void setDeleted(String username) {
         this.isDeleted = true;
     }
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
@@ -2,29 +2,33 @@ package com.example.delivery.domain.model.entity;
 
 import com.example.delivery.domain.model.enums.DeliveryStatus;
 import com.example.delivery.domain.model.vo.Address;
+import com.example.delivery.domain.model.vo.DeliveryStatusRecord;
+import com.example.delivery.libs.exception.CustomException;
+import com.example.delivery.libs.exception.ErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 @Entity
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "p_delivery")
 public class Delivery {
 
@@ -32,9 +36,8 @@ public class Delivery {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private DeliveryStatus deliveryStatus;
+    @Embedded
+    private DeliveryStatusRecord deliveryStatusRecord;
 
     @Embedded
     private Address address;
@@ -42,6 +45,19 @@ public class Delivery {
     @Column(nullable = false)
     private boolean isDeleted = false;
 
+    @Column(name = "deleted_by")
+    private String deletedBy;
+
+    private LocalDateTime deletedAt;
+
+    @Column(nullable = false)
+    private UUID deliveryStaffId;
+
+    @Column(nullable = false)
+    private UUID receiverId;
+
+    @Column(nullable = false)
+    private UUID orderId;
 
     /**
      * HubRoute 값객체로 바꿔야한다 -> 여기서 허브 경로 데이터를 관리해야함
@@ -50,38 +66,102 @@ public class Delivery {
      */
     private UUID startHubId;
     private UUID destinationHubId;
-
-    private UUID deliveryStaffId;
-    private UUID receiverId;
-
-    private UUID orderId;
-
     private UUID hubDeliveryHistoryId;
 
+    // TODO: 원투원 단방향에서 LAZY로딩 적용시 추가 쿼리 실행이 일어나기 때문에 비효율적.  변경이 필요하다면 추후 변경
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "company_delivery_history_id", referencedColumnName = "deliveryHistoryId")
     private CompanyDeliveryHistory companyDeliveryHistory;
 
     @Builder
-    public Delivery(DeliveryStatus deliveryStatus, Address address,
+    private Delivery(DeliveryStatusRecord deliveryStatusRecord, Address address,
                     UUID startHubId, UUID destinationHubId, UUID deliveryStaffId,
                     UUID receiverId, UUID orderId, UUID hubDeliveryHistoryId,
                     CompanyDeliveryHistory companyDeliveryHistory) {
-        this.deliveryStatus = deliveryStatus;
+        this.deliveryStatusRecord = deliveryStatusRecord;
         this.address = address;
         this.startHubId = startHubId;
         this.destinationHubId = destinationHubId;
         this.deliveryStaffId = deliveryStaffId;
+        this.receiverId = receiverId;
         this.orderId = orderId;
         this.hubDeliveryHistoryId = hubDeliveryHistoryId;
         this.companyDeliveryHistory = companyDeliveryHistory;
     }
 
-    public void updateDeliveryStatus(DeliveryStatus deliveryStatus) {
-        this.deliveryStatus = deliveryStatus;
+    public static Delivery of(DeliveryStatusRecord deliveryStatusRecord, Address address,
+                              UUID startHubId, UUID destinationHubId, UUID deliveryStaffId,
+                              UUID receiverId, UUID orderId, UUID hubDeliveryHistoryId,
+                              CompanyDeliveryHistory companyDeliveryHistory){
+
+        validateParam(deliveryStaffId, receiverId, orderId);
+
+        return Delivery.builder()
+                .deliveryStatusRecord(deliveryStatusRecord)
+                .address(address)
+                .startHubId(startHubId)
+                .destinationHubId(destinationHubId)
+                .deliveryStaffId(deliveryStaffId)
+                .receiverId(receiverId)
+                .orderId(orderId)
+                .hubDeliveryHistoryId(hubDeliveryHistoryId)
+                .companyDeliveryHistory(companyDeliveryHistory)
+                .build();
     }
 
-    public void setDeleted() {
+    private static void validateParam(UUID deliveryStaffId, UUID receiverId, UUID orderId) {
+
+        if (deliveryStaffId == null) {
+            throw new CustomException(ErrorCode.INVALID_DELIVERY_STAFF_EMPTY_OR_NULL);
+        }
+        if (receiverId == null) {
+            throw new CustomException(ErrorCode.INVALID_RECEIVER_ID_NULL);
+        }
+        if (orderId == null) {
+            throw new CustomException(ErrorCode.INVALID_ORDER_ID_NULL);
+        }
+    }
+
+    public void update(Address address, UUID deliveryStaffId) {
+        this.address = Optional.ofNullable(address).orElse(this.address);
+        this.deliveryStaffId = Optional.ofNullable(deliveryStaffId).orElse(this.deliveryStaffId);
+    }
+
+    public void updateDeliveryStatus(DeliveryStatus deliveryStatus) {
+        this.deliveryStatusRecord = this.deliveryStatusRecord.updateStatus(deliveryStatus);
+    }
+
+    public void setDeleted(String username) {
         this.isDeleted = true;
+        this.deletedBy = username;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 업체배송경로 변경
+     * 기존 연관관계를 제거하고 새 연관관계를 맺어서
+     * 혹시 모를 잔여 데이터 제거
+     */
+    public void setCompanyDeliveryHistory(CompanyDeliveryHistory companyDeliveryHistory) {
+        checkDeliveryStatus();
+
+        removeExistingCompanyDelivery();
+
+        if (companyDeliveryHistory != null) {
+            this.companyDeliveryHistory = companyDeliveryHistory;
+        }
+    }
+
+    private void removeExistingCompanyDelivery() {
+        if (this.companyDeliveryHistory != null) {
+            this.companyDeliveryHistory = null;
+        }
+    }
+
+    private void checkDeliveryStatus() {
+        if (this.deliveryStatusRecord.getDeliveryStatus() != DeliveryStatus.ARRIVED_AT_DESTINATION_HUB &&
+                this.deliveryStatusRecord.getDeliveryStatus() != DeliveryStatus.BEFORE_DELIVERY_START) {
+            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS);
+        }
     }
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
@@ -1,10 +1,15 @@
 package com.example.delivery.domain.model.entity;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
 import com.example.delivery.domain.model.enums.DeliveryStatus;
 import com.example.delivery.domain.model.vo.Address;
 import com.example.delivery.domain.model.vo.DeliveryStatusRecord;
 import com.example.delivery.libs.exception.CustomException;
 import com.example.delivery.libs.exception.ErrorCode;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -21,10 +26,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.UUID;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -32,136 +33,136 @@ import java.util.UUID;
 @Table(name = "p_delivery")
 public class Delivery {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
 
-    @Embedded
-    private DeliveryStatusRecord deliveryStatusRecord;
+	@Embedded
+	private DeliveryStatusRecord deliveryStatusRecord;
 
-    @Embedded
-    private Address address;
+	@Embedded
+	private Address address;
 
-    @Column(nullable = false)
-    private boolean isDeleted = false;
+	@Column(nullable = false)
+	private boolean isDeleted = false;
 
-    @Column(name = "deleted_by")
-    private String deletedBy;
+	@Column(name = "deleted_by")
+	private String deletedBy;
 
-    private LocalDateTime deletedAt;
+	private LocalDateTime deletedAt;
 
-    @Column(nullable = false)
-    private UUID deliveryStaffId;
+	@Column(nullable = false)
+	private UUID deliveryStaffId;
 
-    @Column(nullable = false)
-    private UUID receiverId;
+	@Column(nullable = false)
+	private UUID receiverId;
 
-    @Column(nullable = false)
-    private UUID orderId;
+	@Column(nullable = false)
+	private UUID orderId;
 
-    /**
-     * HubRoute 값객체로 바꿔야한다 -> 여기서 허브 경로 데이터를 관리해야함
-     * 안바꿔도 된다 -> 허브경로 정보를 여기서는 단순참조만 한다.
-     * 후자 선택
-     */
-    private UUID startHubId;
-    private UUID destinationHubId;
-    private UUID hubDeliveryHistoryId;
+	/**
+	 * HubRoute 값객체로 바꿔야한다 -> 여기서 허브 경로 데이터를 관리해야함
+	 * 안바꿔도 된다 -> 허브경로 정보를 여기서는 단순참조만 한다.
+	 * 후자 선택
+	 */
+	private UUID startHubId;
+	private UUID destinationHubId;
+	private UUID hubDeliveryHistoryId;
 
-    // TODO: 원투원 단방향에서 LAZY로딩 적용시 추가 쿼리 실행이 일어나기 때문에 비효율적.  변경이 필요하다면 추후 변경
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "company_delivery_history_id", referencedColumnName = "deliveryHistoryId")
-    private CompanyDeliveryHistory companyDeliveryHistory;
+	// TODO: 원투원 단방향에서 LAZY로딩 적용시 추가 쿼리 실행이 일어나기 때문에 비효율적.  변경이 필요하다면 추후 변경
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "company_delivery_history_id", referencedColumnName = "deliveryHistoryId")
+	private CompanyDeliveryHistory companyDeliveryHistory;
 
-    @Builder
-    private Delivery(DeliveryStatusRecord deliveryStatusRecord, Address address,
-                    UUID startHubId, UUID destinationHubId, UUID deliveryStaffId,
-                    UUID receiverId, UUID orderId, UUID hubDeliveryHistoryId,
-                    CompanyDeliveryHistory companyDeliveryHistory) {
-        this.deliveryStatusRecord = deliveryStatusRecord;
-        this.address = address;
-        this.startHubId = startHubId;
-        this.destinationHubId = destinationHubId;
-        this.deliveryStaffId = deliveryStaffId;
-        this.receiverId = receiverId;
-        this.orderId = orderId;
-        this.hubDeliveryHistoryId = hubDeliveryHistoryId;
-        this.companyDeliveryHistory = companyDeliveryHistory;
-    }
+	@Builder
+	private Delivery(DeliveryStatusRecord deliveryStatusRecord, Address address,
+		UUID startHubId, UUID destinationHubId, UUID deliveryStaffId,
+		UUID receiverId, UUID orderId, UUID hubDeliveryHistoryId,
+		CompanyDeliveryHistory companyDeliveryHistory) {
+		this.deliveryStatusRecord = deliveryStatusRecord;
+		this.address = address;
+		this.startHubId = startHubId;
+		this.destinationHubId = destinationHubId;
+		this.deliveryStaffId = deliveryStaffId;
+		this.receiverId = receiverId;
+		this.orderId = orderId;
+		this.hubDeliveryHistoryId = hubDeliveryHistoryId;
+		this.companyDeliveryHistory = companyDeliveryHistory;
+	}
 
-    public static Delivery of(DeliveryStatusRecord deliveryStatusRecord, Address address,
-                              UUID startHubId, UUID destinationHubId, UUID deliveryStaffId,
-                              UUID receiverId, UUID orderId, UUID hubDeliveryHistoryId,
-                              CompanyDeliveryHistory companyDeliveryHistory){
+	public static Delivery of(DeliveryStatusRecord deliveryStatusRecord, Address address,
+		UUID startHubId, UUID destinationHubId, UUID deliveryStaffId,
+		UUID receiverId, UUID orderId, UUID hubDeliveryHistoryId,
+		CompanyDeliveryHistory companyDeliveryHistory) {
 
-        validateParam(deliveryStaffId, receiverId, orderId);
+		validateParam(deliveryStaffId, receiverId, orderId);
 
-        return Delivery.builder()
-                .deliveryStatusRecord(deliveryStatusRecord)
-                .address(address)
-                .startHubId(startHubId)
-                .destinationHubId(destinationHubId)
-                .deliveryStaffId(deliveryStaffId)
-                .receiverId(receiverId)
-                .orderId(orderId)
-                .hubDeliveryHistoryId(hubDeliveryHistoryId)
-                .companyDeliveryHistory(companyDeliveryHistory)
-                .build();
-    }
+		return Delivery.builder()
+			.deliveryStatusRecord(deliveryStatusRecord)
+			.address(address)
+			.startHubId(startHubId)
+			.destinationHubId(destinationHubId)
+			.deliveryStaffId(deliveryStaffId)
+			.receiverId(receiverId)
+			.orderId(orderId)
+			.hubDeliveryHistoryId(hubDeliveryHistoryId)
+			.companyDeliveryHistory(companyDeliveryHistory)
+			.build();
+	}
 
-    private static void validateParam(UUID deliveryStaffId, UUID receiverId, UUID orderId) {
+	private static void validateParam(UUID deliveryStaffId, UUID receiverId, UUID orderId) {
 
-        if (deliveryStaffId == null) {
-            throw new CustomException(ErrorCode.INVALID_DELIVERY_STAFF_EMPTY_OR_NULL);
-        }
-        if (receiverId == null) {
-            throw new CustomException(ErrorCode.INVALID_RECEIVER_ID_NULL);
-        }
-        if (orderId == null) {
-            throw new CustomException(ErrorCode.INVALID_ORDER_ID_NULL);
-        }
-    }
+		if (deliveryStaffId == null) {
+			throw new CustomException(ErrorCode.INVALID_DELIVERY_STAFF_EMPTY_OR_NULL);
+		}
+		if (receiverId == null) {
+			throw new CustomException(ErrorCode.INVALID_RECEIVER_ID_NULL);
+		}
+		if (orderId == null) {
+			throw new CustomException(ErrorCode.INVALID_ORDER_ID_NULL);
+		}
+	}
 
-    public void update(Address address, UUID deliveryStaffId) {
-        this.address = Optional.ofNullable(address).orElse(this.address);
-        this.deliveryStaffId = Optional.ofNullable(deliveryStaffId).orElse(this.deliveryStaffId);
-    }
+	public void update(Address address, UUID deliveryStaffId) {
+		this.address = Optional.ofNullable(address).orElse(this.address);
+		this.deliveryStaffId = Optional.ofNullable(deliveryStaffId).orElse(this.deliveryStaffId);
+	}
 
-    public void updateDeliveryStatus(DeliveryStatus deliveryStatus) {
-        this.deliveryStatusRecord = this.deliveryStatusRecord.updateStatus(deliveryStatus);
-    }
+	public void updateDeliveryStatus(DeliveryStatus deliveryStatus) {
+		this.deliveryStatusRecord = this.deliveryStatusRecord.updateStatus(deliveryStatus);
+	}
 
-    public void setDeleted(String username) {
-        this.isDeleted = true;
-        this.deletedBy = username;
-        this.deletedAt = LocalDateTime.now();
-    }
+	public void setDeleted(String username) {
+		this.isDeleted = true;
+		this.deletedBy = username;
+		this.deletedAt = LocalDateTime.now();
+	}
 
-    /**
-     * 업체배송경로 변경
-     * 기존 연관관계를 제거하고 새 연관관계를 맺어서
-     * 혹시 모를 잔여 데이터 제거
-     */
-    public void setCompanyDeliveryHistory(CompanyDeliveryHistory companyDeliveryHistory) {
-        checkDeliveryStatus();
+	/**
+	 * 업체배송경로 변경
+	 * 기존 연관관계를 제거하고 새 연관관계를 맺어서
+	 * 혹시 모를 잔여 데이터 제거
+	 */
+	public void setCompanyDeliveryHistory(CompanyDeliveryHistory companyDeliveryHistory) {
+		checkDeliveryStatus();
 
-        removeExistingCompanyDelivery();
+		removeExistingCompanyDelivery();
 
-        if (companyDeliveryHistory != null) {
-            this.companyDeliveryHistory = companyDeliveryHistory;
-        }
-    }
+		if (companyDeliveryHistory != null) {
+			this.companyDeliveryHistory = companyDeliveryHistory;
+		}
+	}
 
-    private void removeExistingCompanyDelivery() {
-        if (this.companyDeliveryHistory != null) {
-            this.companyDeliveryHistory = null;
-        }
-    }
+	private void removeExistingCompanyDelivery() {
+		if (this.companyDeliveryHistory != null) {
+			this.companyDeliveryHistory = null;
+		}
+	}
 
-    private void checkDeliveryStatus() {
-        if (this.deliveryStatusRecord.getDeliveryStatus() != DeliveryStatus.ARRIVED_AT_DESTINATION_HUB &&
-                this.deliveryStatusRecord.getDeliveryStatus() != DeliveryStatus.BEFORE_DELIVERY_START) {
-            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS);
-        }
-    }
+	private void checkDeliveryStatus() {
+		if (this.deliveryStatusRecord.getDeliveryStatus() != DeliveryStatus.ARRIVED_AT_DESTINATION_HUB &&
+			this.deliveryStatusRecord.getDeliveryStatus() != DeliveryStatus.BEFORE_DELIVERY_START) {
+			throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS);
+		}
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
@@ -58,6 +58,9 @@ public class Delivery {
 	private UUID receiverId;
 
 	@Column(nullable = false)
+	private UUID receiverSlackId;
+
+	@Column(nullable = false)
 	private UUID orderId;
 
 	/**
@@ -77,7 +80,7 @@ public class Delivery {
 	@Builder
 	private Delivery(DeliveryStatusRecord deliveryStatusRecord, Address address,
 		UUID startHubId, UUID destinationHubId, UUID deliveryStaffId,
-		UUID receiverId, UUID orderId, UUID hubDeliveryHistoryId,
+		UUID receiverId, UUID receiverSlackId, UUID orderId, UUID hubDeliveryHistoryId,
 		CompanyDeliveryHistory companyDeliveryHistory) {
 		this.deliveryStatusRecord = deliveryStatusRecord;
 		this.address = address;
@@ -85,6 +88,7 @@ public class Delivery {
 		this.destinationHubId = destinationHubId;
 		this.deliveryStaffId = deliveryStaffId;
 		this.receiverId = receiverId;
+		this.receiverSlackId = receiverSlackId;
 		this.orderId = orderId;
 		this.hubDeliveryHistoryId = hubDeliveryHistoryId;
 		this.companyDeliveryHistory = companyDeliveryHistory;
@@ -92,10 +96,10 @@ public class Delivery {
 
 	public static Delivery of(DeliveryStatusRecord deliveryStatusRecord, Address address,
 		UUID startHubId, UUID destinationHubId, UUID deliveryStaffId,
-		UUID receiverId, UUID orderId, UUID hubDeliveryHistoryId,
+		UUID receiverId, UUID receiverSlackId, UUID orderId, UUID hubDeliveryHistoryId,
 		CompanyDeliveryHistory companyDeliveryHistory) {
 
-		validateParam(deliveryStaffId, receiverId, orderId);
+		validateParam(deliveryStaffId, receiverId, receiverSlackId, orderId);
 
 		return Delivery.builder()
 			.deliveryStatusRecord(deliveryStatusRecord)
@@ -104,19 +108,23 @@ public class Delivery {
 			.destinationHubId(destinationHubId)
 			.deliveryStaffId(deliveryStaffId)
 			.receiverId(receiverId)
+			.receiverSlackId(receiverSlackId)
 			.orderId(orderId)
 			.hubDeliveryHistoryId(hubDeliveryHistoryId)
 			.companyDeliveryHistory(companyDeliveryHistory)
 			.build();
 	}
 
-	private static void validateParam(UUID deliveryStaffId, UUID receiverId, UUID orderId) {
+	private static void validateParam(UUID deliveryStaffId, UUID receiverId, UUID receiverSlackId, UUID orderId) {
 
 		if (deliveryStaffId == null) {
 			throw new CustomException(ErrorCode.INVALID_DELIVERY_STAFF_EMPTY_OR_NULL);
 		}
 		if (receiverId == null) {
 			throw new CustomException(ErrorCode.INVALID_RECEIVER_ID_NULL);
+		}
+		if (receiverSlackId == null) {
+			throw new CustomException(ErrorCode.INVALID_RECEIVER_SLACK_ID_NULL);
 		}
 		if (orderId == null) {
 			throw new CustomException(ErrorCode.INVALID_ORDER_ID_NULL);

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/HubDeliveryHistory.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/HubDeliveryHistory.java
@@ -2,6 +2,8 @@ package com.example.delivery.domain.model.entity;
 
 import com.example.delivery.domain.model.vo.DistanceAndDuration;
 import com.example.delivery.domain.model.vo.HubRoute;
+import com.example.delivery.libs.exception.CustomException;
+import com.example.delivery.libs.exception.ErrorCode;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -11,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,8 +23,8 @@ import java.util.UUID;
 
 @Entity
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "p_hub_delivery_history")
 public class HubDeliveryHistory {
 
@@ -52,21 +55,46 @@ public class HubDeliveryHistory {
     @Column(nullable = false)
     private boolean isDeleted = false;
 
-    private UUID deliveryId;
 
     @Builder
-    public HubDeliveryHistory(HubRoute hubRoute, int sequence,
+    private HubDeliveryHistory(HubRoute hubRoute, int sequence,
                               DistanceAndDuration expectedDistanceAndDuration,
-                              DistanceAndDuration distanceAndDuration,
-                              UUID deliveryId) {
+                              DistanceAndDuration distanceAndDuration) {
         this.hubRoute = hubRoute;
         this.sequence = sequence;
         this.expectedDistanceAndDuration = expectedDistanceAndDuration;
         this.distanceAndDuration = distanceAndDuration;
-        this.deliveryId = deliveryId;
     }
 
-    public void setDeleted() {
+    public static HubDeliveryHistory of(HubRoute hubRoute, int sequence,
+                                              DistanceAndDuration expectedDistanceAndDuration,
+                                              DistanceAndDuration distanceAndDuration) {
+
+        validateParam(sequence, expectedDistanceAndDuration, distanceAndDuration);
+
+        return HubDeliveryHistory.builder()
+                .hubRoute(hubRoute)
+                .sequence(sequence)
+                .expectedDistanceAndDuration(expectedDistanceAndDuration)
+                .distanceAndDuration(distanceAndDuration)
+                .build();
+    }
+
+    private static void validateParam(int sequence,
+                                      DistanceAndDuration expectedDistanceAndDuration,
+                                      DistanceAndDuration distanceAndDuration) {
+        if (sequence < 0) {
+            throw new CustomException(ErrorCode.INVALID_SEQUENCE_NOT_BELOW_ZERO);
+        }
+        if (expectedDistanceAndDuration == null) {
+            throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+        }
+        if (distanceAndDuration == null) {
+            throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+        }
+    }
+
+    public void setDeleted(String username) {
         this.isDeleted = true;
     }
 

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/HubDeliveryHistory.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/HubDeliveryHistory.java
@@ -1,9 +1,12 @@
 package com.example.delivery.domain.model.entity;
 
+import java.util.UUID;
+
 import com.example.delivery.domain.model.vo.DistanceAndDuration;
 import com.example.delivery.domain.model.vo.HubRoute;
 import com.example.delivery.libs.exception.CustomException;
 import com.example.delivery.libs.exception.ErrorCode;
+
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -19,8 +22,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,74 +29,73 @@ import java.util.UUID;
 @Table(name = "p_hub_delivery_history")
 public class HubDeliveryHistory {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID hubDeliveryHistoryId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID hubDeliveryHistoryId;
 
-    @Embedded
-    private HubRoute hubRoute;
+	@Embedded
+	private HubRoute hubRoute;
 
-    @Column(nullable = false)
-    private int sequence;
+	@Column(nullable = false)
+	private int sequence;
 
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "distance", column = @Column(name = "expected_distance", nullable = false)),
-            @AttributeOverride(name = "duration", column = @Column(name = "expected_duration", nullable = false))
-    })
-    private DistanceAndDuration expectedDistanceAndDuration;
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "distance", column = @Column(name = "expected_distance", nullable = false)),
+		@AttributeOverride(name = "duration", column = @Column(name = "expected_duration", nullable = false))
+	})
+	private DistanceAndDuration expectedDistanceAndDuration;
 
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "distance", column = @Column(name = "distance", nullable = false)),
-            @AttributeOverride(name = "duration", column = @Column(name = "duration", nullable = false))
-    })
-    private DistanceAndDuration distanceAndDuration;
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "distance", column = @Column(name = "distance", nullable = false)),
+		@AttributeOverride(name = "duration", column = @Column(name = "duration", nullable = false))
+	})
+	private DistanceAndDuration distanceAndDuration;
 
-    @Column(nullable = false)
-    private boolean isDeleted = false;
+	@Column(nullable = false)
+	private boolean isDeleted = false;
 
+	@Builder
+	private HubDeliveryHistory(HubRoute hubRoute, int sequence,
+		DistanceAndDuration expectedDistanceAndDuration,
+		DistanceAndDuration distanceAndDuration) {
+		this.hubRoute = hubRoute;
+		this.sequence = sequence;
+		this.expectedDistanceAndDuration = expectedDistanceAndDuration;
+		this.distanceAndDuration = distanceAndDuration;
+	}
 
-    @Builder
-    private HubDeliveryHistory(HubRoute hubRoute, int sequence,
-                              DistanceAndDuration expectedDistanceAndDuration,
-                              DistanceAndDuration distanceAndDuration) {
-        this.hubRoute = hubRoute;
-        this.sequence = sequence;
-        this.expectedDistanceAndDuration = expectedDistanceAndDuration;
-        this.distanceAndDuration = distanceAndDuration;
-    }
+	public static HubDeliveryHistory of(HubRoute hubRoute, int sequence,
+		DistanceAndDuration expectedDistanceAndDuration,
+		DistanceAndDuration distanceAndDuration) {
 
-    public static HubDeliveryHistory of(HubRoute hubRoute, int sequence,
-                                              DistanceAndDuration expectedDistanceAndDuration,
-                                              DistanceAndDuration distanceAndDuration) {
+		validateParam(sequence, expectedDistanceAndDuration, distanceAndDuration);
 
-        validateParam(sequence, expectedDistanceAndDuration, distanceAndDuration);
+		return HubDeliveryHistory.builder()
+			.hubRoute(hubRoute)
+			.sequence(sequence)
+			.expectedDistanceAndDuration(expectedDistanceAndDuration)
+			.distanceAndDuration(distanceAndDuration)
+			.build();
+	}
 
-        return HubDeliveryHistory.builder()
-                .hubRoute(hubRoute)
-                .sequence(sequence)
-                .expectedDistanceAndDuration(expectedDistanceAndDuration)
-                .distanceAndDuration(distanceAndDuration)
-                .build();
-    }
+	private static void validateParam(int sequence,
+		DistanceAndDuration expectedDistanceAndDuration,
+		DistanceAndDuration distanceAndDuration) {
+		if (sequence < 0) {
+			throw new CustomException(ErrorCode.INVALID_SEQUENCE_NOT_BELOW_ZERO);
+		}
+		if (expectedDistanceAndDuration == null) {
+			throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+		}
+		if (distanceAndDuration == null) {
+			throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+		}
+	}
 
-    private static void validateParam(int sequence,
-                                      DistanceAndDuration expectedDistanceAndDuration,
-                                      DistanceAndDuration distanceAndDuration) {
-        if (sequence < 0) {
-            throw new CustomException(ErrorCode.INVALID_SEQUENCE_NOT_BELOW_ZERO);
-        }
-        if (expectedDistanceAndDuration == null) {
-            throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
-        }
-        if (distanceAndDuration == null) {
-            throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
-        }
-    }
-
-    public void setDeleted(String username) {
-        this.isDeleted = true;
-    }
+	public void setDeleted(String username) {
+		this.isDeleted = true;
+	}
 
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/enums/DeliveryStatus.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/enums/DeliveryStatus.java
@@ -5,37 +5,36 @@ import com.example.delivery.libs.exception.ErrorCode;
 
 public enum DeliveryStatus {
 
-    WAITING_IN_START_HUB,
-    MOVING_TO_DESTINATION_HUB,
-    ARRIVED_AT_DESTINATION_HUB,
+	WAITING_IN_START_HUB,
+	MOVING_TO_DESTINATION_HUB,
+	ARRIVED_AT_DESTINATION_HUB,
 
-    BEFORE_DELIVERY_START,
-    DELIVERY_IN_PROGRESS,
-    DELIVERY_COMPLETED,
+	BEFORE_DELIVERY_START,
+	DELIVERY_IN_PROGRESS,
+	DELIVERY_COMPLETED,
 
-    DELIVERY_CANCELLED;
+	DELIVERY_CANCELLED;
 
-
-    public boolean canChangeStatus(DeliveryStatus nextStatus) {
-        switch (this) {
-            case WAITING_IN_START_HUB -> {
-                return nextStatus == MOVING_TO_DESTINATION_HUB;
-            }
-            case MOVING_TO_DESTINATION_HUB -> {
-                return nextStatus == ARRIVED_AT_DESTINATION_HUB;
-            }
-            case ARRIVED_AT_DESTINATION_HUB -> {
-                return nextStatus == BEFORE_DELIVERY_START || nextStatus == DELIVERY_CANCELLED;
-            }
-            case BEFORE_DELIVERY_START -> {
-                return nextStatus == DELIVERY_IN_PROGRESS || nextStatus == DELIVERY_CANCELLED;
-            }
-            case DELIVERY_IN_PROGRESS -> {
-                return nextStatus == DELIVERY_COMPLETED || nextStatus == DELIVERY_CANCELLED;
-            }
-            default -> {
-                throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
-            }
-        }
-    }
+	public boolean canChangeStatus(DeliveryStatus nextStatus) {
+		switch (this) {
+			case WAITING_IN_START_HUB -> {
+				return nextStatus == MOVING_TO_DESTINATION_HUB;
+			}
+			case MOVING_TO_DESTINATION_HUB -> {
+				return nextStatus == ARRIVED_AT_DESTINATION_HUB;
+			}
+			case ARRIVED_AT_DESTINATION_HUB -> {
+				return nextStatus == BEFORE_DELIVERY_START || nextStatus == DELIVERY_CANCELLED;
+			}
+			case BEFORE_DELIVERY_START -> {
+				return nextStatus == DELIVERY_IN_PROGRESS || nextStatus == DELIVERY_CANCELLED;
+			}
+			case DELIVERY_IN_PROGRESS -> {
+				return nextStatus == DELIVERY_COMPLETED || nextStatus == DELIVERY_CANCELLED;
+			}
+			default -> {
+				throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
+			}
+		}
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/enums/DeliveryStatus.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/enums/DeliveryStatus.java
@@ -1,10 +1,41 @@
 package com.example.delivery.domain.model.enums;
 
+import com.example.delivery.libs.exception.CustomException;
+import com.example.delivery.libs.exception.ErrorCode;
+
 public enum DeliveryStatus {
 
-    WAITING_IN_HUB,
-    MOVING_TO_HUB,
+    WAITING_IN_START_HUB,
+    MOVING_TO_DESTINATION_HUB,
     ARRIVED_AT_DESTINATION_HUB,
+
+    BEFORE_DELIVERY_START,
     DELIVERY_IN_PROGRESS,
-    DELIVERY_COMPLETED
+    DELIVERY_COMPLETED,
+
+    DELIVERY_CANCELLED;
+
+
+    public boolean canChangeStatus(DeliveryStatus nextStatus) {
+        switch (this) {
+            case WAITING_IN_START_HUB -> {
+                return nextStatus == MOVING_TO_DESTINATION_HUB;
+            }
+            case MOVING_TO_DESTINATION_HUB -> {
+                return nextStatus == ARRIVED_AT_DESTINATION_HUB;
+            }
+            case ARRIVED_AT_DESTINATION_HUB -> {
+                return nextStatus == BEFORE_DELIVERY_START || nextStatus == DELIVERY_CANCELLED;
+            }
+            case BEFORE_DELIVERY_START -> {
+                return nextStatus == DELIVERY_IN_PROGRESS || nextStatus == DELIVERY_CANCELLED;
+            }
+            case DELIVERY_IN_PROGRESS -> {
+                return nextStatus == DELIVERY_COMPLETED || nextStatus == DELIVERY_CANCELLED;
+            }
+            default -> {
+                throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
+            }
+        }
+    }
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/Address.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/Address.java
@@ -6,29 +6,39 @@ import com.example.delivery.libs.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Address {
 
 	@Column(nullable = false)
 	private String fullAddress;
 
-	private Address(String fullAddress) {
-		validateAddress(fullAddress);
-		this.fullAddress = fullAddress.trim();
+	@Column(nullable = false)
+	private double latitude;
+
+	@Column(nullable = false)
+	private double longitude;
+
+	public static Address of(String fullAddress, double latitude, double longitude) {
+		validateAddress(fullAddress, latitude, longitude);
+		return new Address(fullAddress, latitude, longitude);
 	}
 
-	public static Address of(String fullAddress) {
-		return new Address(fullAddress);
-	}
-
-	private static void validateAddress(String fullAddress) {
+	private static void validateAddress(String fullAddress, double latitude, double longitude) {
 		if (fullAddress == null || fullAddress.isBlank()) {
 			throw new CustomException(ErrorCode.INVALID_ADDRESS_EMPTY_OR_NULL);
+		}
+		if (latitude < 33.0 || latitude > 38.5) {
+			throw new CustomException(ErrorCode.INVALID_LATITUDE);
+		}
+		if (longitude < 124.0 || longitude > 132.0) {
+			throw new CustomException(ErrorCode.INVALID_LONGITUDE);
 		}
 	}
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/Address.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/Address.java
@@ -2,6 +2,7 @@ package com.example.delivery.domain.model.vo;
 
 import com.example.delivery.libs.exception.CustomException;
 import com.example.delivery.libs.exception.ErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -13,21 +14,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Address {
 
-    @Column(nullable = false)
-    private String fullAddress;
+	@Column(nullable = false)
+	private String fullAddress;
 
-    private Address(String fullAddress) {
-        validateAddress(fullAddress);
-        this.fullAddress = fullAddress.trim();
-    }
+	private Address(String fullAddress) {
+		validateAddress(fullAddress);
+		this.fullAddress = fullAddress.trim();
+	}
 
-        public static Address of(String fullAddress) {
-            return new Address(fullAddress);
-        }
+	public static Address of(String fullAddress) {
+		return new Address(fullAddress);
+	}
 
-        private static void validateAddress(String fullAddress) {
-        if (fullAddress == null || fullAddress.isBlank()) {
-            throw new CustomException(ErrorCode.INVALID_ADDRESS_EMPTY_OR_NULL);
-        }
-    }
+	private static void validateAddress(String fullAddress) {
+		if (fullAddress == null || fullAddress.isBlank()) {
+			throw new CustomException(ErrorCode.INVALID_ADDRESS_EMPTY_OR_NULL);
+		}
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/Address.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/Address.java
@@ -21,11 +21,11 @@ public class Address {
         this.fullAddress = fullAddress.trim();
     }
 
-    public static Address of(String fullAddress) {
-        return new Address(fullAddress);
-    }
+        public static Address of(String fullAddress) {
+            return new Address(fullAddress);
+        }
 
-    private static void validateAddress(String fullAddress) {
+        private static void validateAddress(String fullAddress) {
         if (fullAddress == null || fullAddress.isBlank()) {
             throw new CustomException(ErrorCode.INVALID_ADDRESS_EMPTY_OR_NULL);
         }

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/DeliveryStatusRecord.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/DeliveryStatusRecord.java
@@ -1,0 +1,56 @@
+package com.example.delivery.domain.model.vo;
+
+import com.example.delivery.domain.model.enums.DeliveryStatus;
+import com.example.delivery.libs.exception.CustomException;
+import com.example.delivery.libs.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+
+@Embeddable
+@Slf4j
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeliveryStatusRecord {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DeliveryStatus deliveryStatus;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static DeliveryStatusRecord of(DeliveryStatus deliveryStatus) {
+        validate(deliveryStatus);
+        return new DeliveryStatusRecord(deliveryStatus, LocalDateTime.now());
+    }
+
+    public DeliveryStatusRecord updateStatus(DeliveryStatus updatedDeliveryStatus) {
+        validate(updatedDeliveryStatus);
+        if (!this.deliveryStatus.canChangeStatus(updatedDeliveryStatus)) {
+            log.info("변경 실패 : currentStatus={}, nextStatus={}",this.deliveryStatus, updatedDeliveryStatus);
+            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
+        }
+        return new DeliveryStatusRecord(updatedDeliveryStatus, LocalDateTime.now());
+    }
+
+    private static void validate(DeliveryStatus deliveryStatus) {
+        if (deliveryStatus == null) {
+            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_NULL);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Status : " + deliveryStatus + ", updatedAt : " + updatedAt;
+    }
+}

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/DeliveryStatusRecord.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/DeliveryStatusRecord.java
@@ -3,6 +3,7 @@ package com.example.delivery.domain.model.vo;
 import com.example.delivery.domain.model.enums.DeliveryStatus;
 import com.example.delivery.libs.exception.CustomException;
 import com.example.delivery.libs.exception.ErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
@@ -22,35 +23,35 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DeliveryStatusRecord {
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private DeliveryStatus deliveryStatus;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private DeliveryStatus deliveryStatus;
 
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
 
-    public static DeliveryStatusRecord of(DeliveryStatus deliveryStatus) {
-        validate(deliveryStatus);
-        return new DeliveryStatusRecord(deliveryStatus, LocalDateTime.now());
-    }
+	public static DeliveryStatusRecord of(DeliveryStatus deliveryStatus) {
+		validate(deliveryStatus);
+		return new DeliveryStatusRecord(deliveryStatus, LocalDateTime.now());
+	}
 
-    public DeliveryStatusRecord updateStatus(DeliveryStatus updatedDeliveryStatus) {
-        validate(updatedDeliveryStatus);
-        if (!this.deliveryStatus.canChangeStatus(updatedDeliveryStatus)) {
-            log.info("변경 실패 : currentStatus={}, nextStatus={}",this.deliveryStatus, updatedDeliveryStatus);
-            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
-        }
-        return new DeliveryStatusRecord(updatedDeliveryStatus, LocalDateTime.now());
-    }
+	public DeliveryStatusRecord updateStatus(DeliveryStatus updatedDeliveryStatus) {
+		validate(updatedDeliveryStatus);
+		if (!this.deliveryStatus.canChangeStatus(updatedDeliveryStatus)) {
+			log.info("변경 실패 : currentStatus={}, nextStatus={}", this.deliveryStatus, updatedDeliveryStatus);
+			throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
+		}
+		return new DeliveryStatusRecord(updatedDeliveryStatus, LocalDateTime.now());
+	}
 
-    private static void validate(DeliveryStatus deliveryStatus) {
-        if (deliveryStatus == null) {
-            throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_NULL);
-        }
-    }
+	private static void validate(DeliveryStatus deliveryStatus) {
+		if (deliveryStatus == null) {
+			throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_NULL);
+		}
+	}
 
-    @Override
-    public String toString() {
-        return "Status : " + deliveryStatus + ", updatedAt : " + updatedAt;
-    }
+	@Override
+	public String toString() {
+		return "Status : " + deliveryStatus + ", updatedAt : " + updatedAt;
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/DistanceAndDuration.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/DistanceAndDuration.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DistanceAndDuration {
 
     @Column(nullable = false)

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/DistanceAndDuration.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/DistanceAndDuration.java
@@ -2,6 +2,7 @@ package com.example.delivery.domain.model.vo;
 
 import com.example.delivery.libs.exception.CustomException;
 import com.example.delivery.libs.exception.ErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -15,34 +16,34 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DistanceAndDuration {
 
-    @Column(nullable = false)
-    private double distance;
+	@Column(nullable = false)
+	private double distance;
 
-    @Column(nullable = false)
-    private int duration;
+	@Column(nullable = false)
+	private int duration;
 
-    public static DistanceAndDuration of(double distance, int duration) {
-        validateDistance(distance);
-        validateDuration(duration);
+	public static DistanceAndDuration of(double distance, int duration) {
+		validateDistance(distance);
+		validateDuration(duration);
 
-        return new DistanceAndDuration(distance, duration);
-    }
+		return new DistanceAndDuration(distance, duration);
+	}
 
-    @Override
-    public String toString() {
-        return "Distance : " + distance + "km,  Duration : " + duration + "mins";
-    }
+	@Override
+	public String toString() {
+		return "Distance : " + distance + "km,  Duration : " + duration + "mins";
+	}
 
-    private static void validateDuration(int duration) {
-        if (duration < 0) {
-            throw new CustomException(ErrorCode.INVALID_DURATION_NOT_BELOW_ZERO);
-        }
-    }
+	private static void validateDuration(int duration) {
+		if (duration < 0) {
+			throw new CustomException(ErrorCode.INVALID_DURATION_NOT_BELOW_ZERO);
+		}
+	}
 
-    private static void validateDistance(double distance) {
-        if (distance < 0) {
-            throw new CustomException(ErrorCode.INVALID_DISTANCE_NOT_BELOW_ZERO);
-        }
-    }
+	private static void validateDistance(double distance) {
+		if (distance < 0) {
+			throw new CustomException(ErrorCode.INVALID_DISTANCE_NOT_BELOW_ZERO);
+		}
+	}
 
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/HubRoute.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/HubRoute.java
@@ -2,6 +2,7 @@ package com.example.delivery.domain.model.vo;
 
 import com.example.delivery.libs.exception.CustomException;
 import com.example.delivery.libs.exception.ErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -18,27 +19,27 @@ import java.util.UUID;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class HubRoute {
 
-    @Column(nullable = false)
-    private UUID startHubId;
+	@Column(nullable = false)
+	private UUID startHubId;
 
-    @Column(nullable = false)
-    private UUID destinationHubId;
+	@Column(nullable = false)
+	private UUID destinationHubId;
 
-    public static HubRoute of(UUID startHubId, UUID destinationHubId) {
-        validateHubId(startHubId, destinationHubId);
-        validateHubIdsNotEquals(startHubId, destinationHubId);
-        return new HubRoute(startHubId, destinationHubId);
-    }
+	public static HubRoute of(UUID startHubId, UUID destinationHubId) {
+		validateHubId(startHubId, destinationHubId);
+		validateHubIdsNotEquals(startHubId, destinationHubId);
+		return new HubRoute(startHubId, destinationHubId);
+	}
 
-    private static void validateHubIdsNotEquals(UUID startHubId, UUID destinationHubId) {
-        if (Objects.equals(startHubId, destinationHubId)) {
-            throw new CustomException(ErrorCode.INVALID_HUB_ID_EQUALS);
-        }
-    }
+	private static void validateHubIdsNotEquals(UUID startHubId, UUID destinationHubId) {
+		if (Objects.equals(startHubId, destinationHubId)) {
+			throw new CustomException(ErrorCode.INVALID_HUB_ID_EQUALS);
+		}
+	}
 
-    private static void validateHubId(UUID startHubId, UUID destinationHubId) {
-        if (startHubId == null || destinationHubId == null) {
-            throw new CustomException(ErrorCode.INVALID_HUB_ID_NULL);
-        }
-    }
+	private static void validateHubId(UUID startHubId, UUID destinationHubId) {
+		if (startHubId == null || destinationHubId == null) {
+			throw new CustomException(ErrorCode.INVALID_HUB_ID_NULL);
+		}
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/HubRoute.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/HubRoute.java
@@ -9,12 +9,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
 import java.util.UUID;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class HubRoute {
 
     @Column(nullable = false)
@@ -30,7 +31,7 @@ public class HubRoute {
     }
 
     private static void validateHubIdsNotEquals(UUID startHubId, UUID destinationHubId) {
-        if (startHubId.equals(destinationHubId)) {
+        if (Objects.equals(startHubId, destinationHubId)) {
             throw new CustomException(ErrorCode.INVALID_HUB_ID_EQUALS);
         }
     }

--- a/delivery/src/main/java/com/example/delivery/libs/dto/ExceptionResponse.java
+++ b/delivery/src/main/java/com/example/delivery/libs/dto/ExceptionResponse.java
@@ -7,11 +7,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class ExceptionResponse<T> {
 
-    private final Integer status;
-    private final String message;
-    private final T data;
+	private final Integer status;
+	private final String message;
+	private final T data;
 
-    public static <T> ExceptionResponse<T> of(Integer status, String message, T data) {
-        return new ExceptionResponse<>(status, message, data);
-    }
+	public static <T> ExceptionResponse<T> of(Integer status, String message, T data) {
+		return new ExceptionResponse<>(status, message, data);
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/libs/exception/CustomException.java
+++ b/delivery/src/main/java/com/example/delivery/libs/exception/CustomException.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
 
-    private final ErrorCode errorCode;
-    private final String message;
+	private final ErrorCode errorCode;
+	private final String message;
 
-    public CustomException(ErrorCode errorCode) {
-        this.errorCode = errorCode;
-        this.message = errorCode.getMessage();
-    }
+	public CustomException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+		this.message = errorCode.getMessage();
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
+++ b/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
@@ -7,46 +7,45 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    /*  400 BAD_REQUEST : 잘못된 요청  */
-    INVALID_DISTANCE_NOT_BELOW_ZERO(400, "유효하지않은 거리입니다.  거리는 마이너스가 될 수 없습니다."),
-    INVALID_DURATION_NOT_BELOW_ZERO(400, "유효하지않은 시간입니다. 시간은 마이너스가 될 수 없습니다."),
-    INVALID_SEQUENCE_NOT_BELOW_ZERO(400, "유효하지않은 배송순서입니다. 순서는 마이너스가 될 수 없습니다."),
-    INVALID_ADDRESS_EMPTY_OR_NULL(400, "유효하지않은 주소입니다. 공백 또는 NULL이 될 수 없습니다."),
-    INVALID_DELIVERY_STAFF_EMPTY_OR_NULL(400, "유효하지않은 배송담당자입니다. 공백 또는 NULL이 될 수 없습니다."),
-    INVALID_RECEIVER_ID_NULL(400, "유효하지않은 수령인 ID입니다. NULL이 될 수 없습니다."),
-    INVALID_ORDER_ID_NULL(400, "유효하지않은 주문 ID입니다. NULL이 될 수 없습니다."),
-    INVALID_DELIVERY_STATUS_NULL(400, "유효하지않은 배송상태입니다. NULL이 될 수 없습니다."),
-    INVALID_HUB_ID_NULL(400, "유효하지않은 허브 ID입니다. 허브 ID는 NULL이 될 수 없습니다."),
-    INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL(400, "유효하지않은 거리 또는 시간입니다. NULL이 될 수 없습니다."),
-    INVALID_HUB_ID_EQUALS(400, "유효하지않은 허브 ID입니다. 출발지 허브 ID와 도착지 허브 ID는 같을 수 없습니다."),
-    INVALID_DELIVERY_STATUS(400, "유효하지않은 배송상태입니다. 허브에 도착 했거나, 배송 시작 전 이어야 합니다."),
-    INVALID_DELIVERY_STATUS_CHANGE(400, "유효하지않은 배송상태입니다."),
+	/*  400 BAD_REQUEST : 잘못된 요청  */
+	INVALID_DISTANCE_NOT_BELOW_ZERO(400, "유효하지않은 거리입니다.  거리는 마이너스가 될 수 없습니다."),
+	INVALID_DURATION_NOT_BELOW_ZERO(400, "유효하지않은 시간입니다. 시간은 마이너스가 될 수 없습니다."),
+	INVALID_SEQUENCE_NOT_BELOW_ZERO(400, "유효하지않은 배송순서입니다. 순서는 마이너스가 될 수 없습니다."),
+	INVALID_ADDRESS_EMPTY_OR_NULL(400, "유효하지않은 주소입니다. 공백 또는 NULL이 될 수 없습니다."),
+	INVALID_DELIVERY_STAFF_EMPTY_OR_NULL(400, "유효하지않은 배송담당자입니다. 공백 또는 NULL이 될 수 없습니다."),
+	INVALID_RECEIVER_ID_NULL(400, "유효하지않은 수령인 ID입니다. NULL이 될 수 없습니다."),
+	INVALID_ORDER_ID_NULL(400, "유효하지않은 주문 ID입니다. NULL이 될 수 없습니다."),
+	INVALID_DELIVERY_STATUS_NULL(400, "유효하지않은 배송상태입니다. NULL이 될 수 없습니다."),
+	INVALID_HUB_ID_NULL(400, "유효하지않은 허브 ID입니다. 허브 ID는 NULL이 될 수 없습니다."),
+	INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL(400, "유효하지않은 거리 또는 시간입니다. NULL이 될 수 없습니다."),
+	INVALID_HUB_ID_EQUALS(400, "유효하지않은 허브 ID입니다. 출발지 허브 ID와 도착지 허브 ID는 같을 수 없습니다."),
+	INVALID_DELIVERY_STATUS(400, "유효하지않은 배송상태입니다. 허브에 도착 했거나, 배송 시작 전 이어야 합니다."),
+	INVALID_DELIVERY_STATUS_CHANGE(400, "유효하지않은 배송상태입니다."),
 
-    /*  401 UNAUTHORIZED : 인증 안됨  */
-    UNAUTHORIZED(401, "인증되지 않았습니다."),
+	/*  401 UNAUTHORIZED : 인증 안됨  */
+	UNAUTHORIZED(401, "인증되지 않았습니다."),
 
-    /*  403 FORBIDDEN : 권한 없음  */
-    FORBIDDEN(403, "권한이 없습니다."),
+	/*  403 FORBIDDEN : 권한 없음  */
+	FORBIDDEN(403, "권한이 없습니다."),
 
-    /*  404 NOT_FOUND : Resource 권한 없음, Resource 를 찾을 수 없음  */
-    ACCESS_DENIED(404, "접근 권한이 없습니다."),
-    ORDER_NOT_FOUND(404, "주문을 찾을 수 없습니다."),
-    PRODUCT_NOT_FOUND(404, "상품을 찾을 수 없습니다."),
+	/*  404 NOT_FOUND : Resource 권한 없음, Resource 를 찾을 수 없음  */
+	ACCESS_DENIED(404, "접근 권한이 없습니다."),
+	ORDER_NOT_FOUND(404, "주문을 찾을 수 없습니다."),
+	PRODUCT_NOT_FOUND(404, "상품을 찾을 수 없습니다."),
 
-    /*  408 REQUEST_TIMEOUT : 요청에 대한 응답 시간 초과  */
-    TIMEOUT_ERROR(408, "응답시간을 초과하였습니다."),
+	/*  408 REQUEST_TIMEOUT : 요청에 대한 응답 시간 초과  */
+	TIMEOUT_ERROR(408, "응답시간을 초과하였습니다."),
 
-    /*  409 CONFLICT : Resource 중복  */
-    ALREADY_EXIST_USERID(409, "이미 존재하는 USERID 입니다."),
+	/*  409 CONFLICT : Resource 중복  */
+	ALREADY_EXIST_USERID(409, "이미 존재하는 USERID 입니다."),
 
-    /*  500 INTERNAL_SERVER_ERROR : 서버 에러  */
-    INTERNAL_SERVER_ERROR(500, "내부 서버 에러입니다."),
-    ORDER_SERVER_ERROR(500, "PRODUCT 서버 에러입니다."),
-    INTERRUPTED_ERROR(500, " Interrupted 에러 발생."),
+	/*  500 INTERNAL_SERVER_ERROR : 서버 에러  */
+	INTERNAL_SERVER_ERROR(500, "내부 서버 에러입니다."),
+	ORDER_SERVER_ERROR(500, "PRODUCT 서버 에러입니다."),
+	INTERRUPTED_ERROR(500, " Interrupted 에러 발생."),
 
-    /*  502 BAD_GATEWAY  연결 실패   */
-    ;
+	/*  502 BAD_GATEWAY  연결 실패   */;
 
-    private final Integer httpStatus;
-    private final String message;
+	private final Integer httpStatus;
+	private final String message;
 }

--- a/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
+++ b/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 	INVALID_ADDRESS_EMPTY_OR_NULL(400, "유효하지않은 주소입니다. 공백 또는 NULL이 될 수 없습니다."),
 	INVALID_DELIVERY_STAFF_EMPTY_OR_NULL(400, "유효하지않은 배송담당자입니다. 공백 또는 NULL이 될 수 없습니다."),
 	INVALID_RECEIVER_ID_NULL(400, "유효하지않은 수령인 ID입니다. NULL이 될 수 없습니다."),
+	INVALID_RECEIVER_SLACK_ID_NULL(400, "유효하지않은 수령인 슬랙 ID입니다. NULL이 될 수 없습니다."),
 	INVALID_ORDER_ID_NULL(400, "유효하지않은 주문 ID입니다. NULL이 될 수 없습니다."),
 	INVALID_DELIVERY_STATUS_NULL(400, "유효하지않은 배송상태입니다. NULL이 될 수 없습니다."),
 	INVALID_HUB_ID_NULL(400, "유효하지않은 허브 ID입니다. 허브 ID는 NULL이 될 수 없습니다."),
@@ -21,6 +22,8 @@ public enum ErrorCode {
 	INVALID_HUB_ID_EQUALS(400, "유효하지않은 허브 ID입니다. 출발지 허브 ID와 도착지 허브 ID는 같을 수 없습니다."),
 	INVALID_DELIVERY_STATUS(400, "유효하지않은 배송상태입니다. 허브에 도착 했거나, 배송 시작 전 이어야 합니다."),
 	INVALID_DELIVERY_STATUS_CHANGE(400, "유효하지않은 배송상태입니다."),
+	INVALID_LATITUDE(400, "유효하지않은 위도입니다. 대한민국의 위도는 북쪽 약 38.5  남쪽 약 33.0의 위도 내에 위치해야 합니다."),
+	INVALID_LONGITUDE(400, "유효하지않은 경도입니다. 대한민국의 경도는 서쪽 약 124.0  동쪽 약 132.0의 위도 내에 위치해야 합니다."),
 
 	/*  401 UNAUTHORIZED : 인증 안됨  */
 	UNAUTHORIZED(401, "인증되지 않았습니다."),

--- a/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
+++ b/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
@@ -10,9 +10,17 @@ public enum ErrorCode {
     /*  400 BAD_REQUEST : 잘못된 요청  */
     INVALID_DISTANCE_NOT_BELOW_ZERO(400, "유효하지않은 거리입니다.  거리는 마이너스가 될 수 없습니다."),
     INVALID_DURATION_NOT_BELOW_ZERO(400, "유효하지않은 시간입니다. 시간은 마이너스가 될 수 없습니다."),
+    INVALID_SEQUENCE_NOT_BELOW_ZERO(400, "유효하지않은 배송순서입니다. 순서는 마이너스가 될 수 없습니다."),
     INVALID_ADDRESS_EMPTY_OR_NULL(400, "유효하지않은 주소입니다. 공백 또는 NULL이 될 수 없습니다."),
+    INVALID_DELIVERY_STAFF_EMPTY_OR_NULL(400, "유효하지않은 배송담당자입니다. 공백 또는 NULL이 될 수 없습니다."),
+    INVALID_RECEIVER_ID_NULL(400, "유효하지않은 수령인 ID입니다. NULL이 될 수 없습니다."),
+    INVALID_ORDER_ID_NULL(400, "유효하지않은 주문 ID입니다. NULL이 될 수 없습니다."),
+    INVALID_DELIVERY_STATUS_NULL(400, "유효하지않은 배송상태입니다. NULL이 될 수 없습니다."),
     INVALID_HUB_ID_NULL(400, "유효하지않은 허브 ID입니다. 허브 ID는 NULL이 될 수 없습니다."),
+    INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL(400, "유효하지않은 거리 또는 시간입니다. NULL이 될 수 없습니다."),
     INVALID_HUB_ID_EQUALS(400, "유효하지않은 허브 ID입니다. 출발지 허브 ID와 도착지 허브 ID는 같을 수 없습니다."),
+    INVALID_DELIVERY_STATUS(400, "유효하지않은 배송상태입니다. 허브에 도착 했거나, 배송 시작 전 이어야 합니다."),
+    INVALID_DELIVERY_STATUS_CHANGE(400, "유효하지않은 배송상태입니다."),
 
     /*  401 UNAUTHORIZED : 인증 안됨  */
     UNAUTHORIZED(401, "인증되지 않았습니다."),

--- a/delivery/src/main/java/com/example/delivery/libs/exception/GlobalExceptionHandler.java
+++ b/delivery/src/main/java/com/example/delivery/libs/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.example.delivery.libs.exception;
 
 import com.example.delivery.libs.dto.ExceptionResponse;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,38 +12,38 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    /**
-     * [Exception] CustomException 반환 ErrorCode에 작성된 예외를 반환하는 경우 사용
-     *
-     * @param e CustomException
-     * @return ResponseEntity<ExceptionResponse>
-     */
-    @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ExceptionResponse<Void>> customExceptionHandler(CustomException e) {
-        log.error("CustomException: " + e);
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(
-                ExceptionResponse.of(
-                        e.getErrorCode().getHttpStatus(),
-                        e.getErrorCode().getMessage(),
-                        null
-                )
-        );
-    }
+	/**
+	 * [Exception] CustomException 반환 ErrorCode에 작성된 예외를 반환하는 경우 사용
+	 *
+	 * @param e CustomException
+	 * @return ResponseEntity<ExceptionResponse>
+	 */
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ExceptionResponse<Void>> customExceptionHandler(CustomException e) {
+		log.error("CustomException: " + e);
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(
+			ExceptionResponse.of(
+				e.getErrorCode().getHttpStatus(),
+				e.getErrorCode().getMessage(),
+				null
+			)
+		);
+	}
 
-    /**
-     * [Exception] RuntimeException 반환
-     *
-     * @param e RuntimeException
-     * @return ResponseEntity<ExceptionResponse>
-     */
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ExceptionResponse<Void>> runtimeExceptionHandler(RuntimeException e) {
-        log.error("RuntimeException: ", e);
-        return ResponseEntity.internalServerError().body(
-                ExceptionResponse.of(
-                        ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus(),
-                        ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
-                        null)
-        );
-    }
+	/**
+	 * [Exception] RuntimeException 반환
+	 *
+	 * @param e RuntimeException
+	 * @return ResponseEntity<ExceptionResponse>
+	 */
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ExceptionResponse<Void>> runtimeExceptionHandler(RuntimeException e) {
+		log.error("RuntimeException: ", e);
+		return ResponseEntity.internalServerError().body(
+			ExceptionResponse.of(
+				ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus(),
+				ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+				null)
+		);
+	}
 }

--- a/delivery/src/main/java/com/example/delivery/presentation/client/DeliveryStaffClient.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/client/DeliveryStaffClient.java
@@ -9,6 +9,6 @@ import java.util.UUID;
 @FeignClient(name = "delivery-staff-service")
 public interface DeliveryStaffClient {
 
-//    @GetMapping(uri)
-//    DeliveryStaffDto getDeliveryStaffById(@PathVariable UUID id);
+	//    @GetMapping(uri)
+	//    DeliveryStaffDto getDeliveryStaffById(@PathVariable UUID id);
 }

--- a/delivery/src/main/java/com/example/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/controller/DeliveryController.java
@@ -1,0 +1,9 @@
+package com.example.delivery.presentation.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/")
+public class DeliveryController {
+}

--- a/delivery/src/main/java/com/example/delivery/presentation/dto/CreateDeliveryRequestDto.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/dto/CreateDeliveryRequestDto.java
@@ -1,0 +1,2 @@
+package com.example.delivery.presentation.dto;public record CreateDeliveryRequestDto() {
+}

--- a/delivery/src/test/java/com/example/delivery/DeliveryApplicationTests.java
+++ b/delivery/src/test/java/com/example/delivery/DeliveryApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class DeliveryApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
+	@Test
+	void contextLoads() {
+	}
 
 }

--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -1,50 +1,50 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.0'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:3.1.0'
-	implementation 'org.springframework.cloud:spring-cloud-starter-config:3.1.0'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:3.1.0'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config:3.1.0'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// queryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // queryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.withType(Test) {
-	enabled = false
+    enabled = false
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -1,50 +1,50 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.0'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2024.0.0")
+    set('springCloudVersion', "2024.0.0")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/example/logistics_eureka/Application.java
+++ b/src/main/java/com/example/logistics_eureka/Application.java
@@ -8,8 +8,8 @@ import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 @EnableEurekaServer
 public class Application {
 
-    public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
 
 }

--- a/src/test/java/com/example/logistics_eureka/ApplicationTests.java
+++ b/src/test/java/com/example/logistics_eureka/ApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
+	@Test
+	void contextLoads() {
+	}
 
 }


### PR DESCRIPTION
루트 애그리거트 - delivery

delivery를 통해서만  배송경로 하위엔티티 접근 가능

허브 배송경로는 논리적으로 수정과 삭제가 불필요함 (허브에서 생성한 후 배송에서는 저장과 조회 기능만 담당하기 때문)

업체 배송경로는 delivery 엔티티의 set을 통해 연관관계를 끊고 다시 맺음으로써 해당 배송id의 배송경로를 변경가능

 <br> <br>

네이버 컨벤션 적용
