### PR TITLE
Feat/delivery  update ,  status update , delete  구현

### DIFF
--- a/delivery/build.gradle
+++ b/delivery/build.gradle
@@ -28,6 +28,9 @@ ext {
 }
 
 dependencies {
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -38,8 +41,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
     runtimeOnly 'org.postgresql:postgresql'
 }

--- a/delivery/src/main/java/com/example/delivery/application/dto/CreateDeliveryResponseDto.java
+++ b/delivery/src/main/java/com/example/delivery/application/dto/CreateDeliveryResponseDto.java
@@ -11,7 +11,7 @@ public record CreateDeliveryResponseDto(
 	UUID startHubId,
 	UUID destinationHubId,
 	UUID receiverId,
-	UUID receiverSlackId,
+	String receiverSlackId,
 	String address,
 	String status,
 	LocalDateTime updatedAt,

--- a/delivery/src/main/java/com/example/delivery/application/dto/CreateDeliveryResponseDto.java
+++ b/delivery/src/main/java/com/example/delivery/application/dto/CreateDeliveryResponseDto.java
@@ -19,5 +19,4 @@ public record CreateDeliveryResponseDto(
 	int expectedDuration
 
 ) {
-
 }

--- a/delivery/src/main/java/com/example/delivery/application/dto/UpdateDeliveryResponseDto.java
+++ b/delivery/src/main/java/com/example/delivery/application/dto/UpdateDeliveryResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.delivery.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UpdateDeliveryResponseDto(
+
+	UUID deliveryId,
+	String address,
+	String status,
+	LocalDateTime updatedAt
+
+) {
+}

--- a/delivery/src/main/java/com/example/delivery/application/dto/UpdateDeliveryStatusResponseDto.java
+++ b/delivery/src/main/java/com/example/delivery/application/dto/UpdateDeliveryStatusResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.delivery.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UpdateDeliveryStatusResponseDto(
+	UUID deliveryId,
+	String status,
+	LocalDateTime updatedAt
+
+) {
+}

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryCancelService.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryCancelService.java
@@ -1,0 +1,9 @@
+package com.example.delivery.application.service;
+
+import java.util.UUID;
+
+public interface DeliveryCancelService {
+
+	void cancelDelivery(UUID deliveryId);
+
+}

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryFacadeService.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryFacadeService.java
@@ -1,0 +1,9 @@
+package com.example.delivery.application.service;
+
+import java.util.UUID;
+
+public interface DeliveryFacadeService {
+
+	void updateDeliveryStatusAndNotifyToSlack(UUID deliveryId);
+
+}

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryFacadeServiceImpl.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryFacadeServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.delivery.application.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.example.delivery.domain.model.entity.Delivery;
+import com.example.delivery.infrastructure.messaging.DeliveryStatusPublisher;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryFacadeServiceImpl implements DeliveryFacadeService{
+
+	private final DeliveryService deliveryService;
+	private final DeliveryStatusPublisher deliveryStatusPublisher;
+
+	@Override
+	@Transactional
+	public void updateDeliveryStatusAndNotifyToSlack(UUID deliveryId) {
+		Delivery delivery = deliveryService.updateDeliveryStatus(deliveryId);
+
+		deliveryStatusPublisher.publish(deliveryId,
+			delivery.getDeliveryStatusRecord().getDeliveryStatus().name(),
+			delivery.getDeliveryStatusRecord().getUpdatedAt());
+	}
+
+}

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryFacadeServiceImpl.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryFacadeServiceImpl.java
@@ -22,7 +22,7 @@ public class DeliveryFacadeServiceImpl implements DeliveryFacadeService{
 	public void updateDeliveryStatusAndNotifyToSlack(UUID deliveryId) {
 		Delivery delivery = deliveryService.updateDeliveryStatus(deliveryId);
 
-		deliveryStatusPublisher.publish(deliveryId,
+		deliveryStatusPublisher.publish(delivery.getReceiverSlackId(), deliveryId,
 			delivery.getDeliveryStatusRecord().getDeliveryStatus().name(),
 			delivery.getDeliveryStatusRecord().getUpdatedAt());
 	}

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryService.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryService.java
@@ -1,4 +1,4 @@
 package com.example.delivery.application.service;
 
-public interface DeliveryService extends  DeliveryCreateService, DeliveryUpdateService {
+public interface DeliveryService extends  DeliveryCreateService, DeliveryUpdateService, DeliveryStatusUpdateService {
 }

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryService.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryService.java
@@ -1,4 +1,5 @@
 package com.example.delivery.application.service;
 
-public interface DeliveryService extends  DeliveryCreateService, DeliveryUpdateService, DeliveryStatusUpdateService {
+public interface DeliveryService extends
+	DeliveryCreateService, DeliveryUpdateService, DeliveryStatusUpdateService, DeliveryCancelService {
 }

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryService.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryService.java
@@ -1,4 +1,4 @@
 package com.example.delivery.application.service;
 
-public interface DeliveryService extends  DeliveryCreateService {
+public interface DeliveryService extends  DeliveryCreateService, DeliveryUpdateService {
 }

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryServiceImpl.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryServiceImpl.java
@@ -115,6 +115,7 @@ public class DeliveryServiceImpl implements DeliveryService{
 		 *
 		 */
 
+
 		checkDeliveryStatus(delivery.getDeliveryStatusRecord().getDeliveryStatus());
 		delivery.update(updatedAddress, null, companyDeliveryStaffId);
 		// delivery.setCompanyDeliveryHistory(updatedHistory);

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryServiceImpl.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryServiceImpl.java
@@ -1,18 +1,24 @@
 package com.example.delivery.application.service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.delivery.application.dto.CreateDeliveryResponseDto;
+import com.example.delivery.application.dto.UpdateDeliveryResponseDto;
 import com.example.delivery.domain.model.entity.Delivery;
 import com.example.delivery.domain.model.enums.DeliveryStatus;
 import com.example.delivery.domain.model.vo.Address;
 import com.example.delivery.domain.model.vo.DeliveryStatusRecord;
+import com.example.delivery.domain.model.vo.DistanceAndDuration;
 import com.example.delivery.domain.repository.DeliveryRepository;
 import com.example.delivery.infrastructure.client.HubClient;
+import com.example.delivery.libs.exception.CustomException;
+import com.example.delivery.libs.exception.ErrorCode;
 import com.example.delivery.presentation.dto.CreateDeliveryRequestDto;
+import com.example.delivery.presentation.dto.UpdateDeliveryRequestDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -39,16 +45,18 @@ public class DeliveryServiceImpl implements DeliveryService{
 		UUID hubDeliveryStaffId = assignDeliveryStaffService.assignHubDeliveryStaff();
 		UUID companyDeliveryStaffId = assignDeliveryStaffService.assignCompanyDeliveryStaff(requestDto.destinationHubId());
 
+		validateParam(hubDeliveryStaffId, companyDeliveryStaffId, requestDto.receiverId(), requestDto.receiverSlackId(), requestDto.orderId());
+
 		Delivery delivery = Delivery.of(
 			DeliveryStatusRecord.of(DeliveryStatus.WAITING_IN_START_HUB),
 			Address.of(requestDto.address(), 0, 0),
 			requestDto.startHubId(),
 			requestDto.destinationHubId(),
+			hubDeliveryStaffId,
+			companyDeliveryStaffId,
 			requestDto.receiverId(),
 			requestDto.receiverSlackId(),
 			requestDto.orderId(),
-			hubDeliveryStaffId,
-			companyDeliveryStaffId,
 			null,
 			null
 		);
@@ -70,5 +78,90 @@ public class DeliveryServiceImpl implements DeliveryService{
 			1.0,
 			1
 		);
+	}
+
+	@Override
+	public UpdateDeliveryResponseDto updateDelivery(UUID deliveryId, UpdateDeliveryRequestDto requestDto) {
+		/**
+		 * authClient에서 유저 ID로 권한확인.  마스터인지
+		 * order의 주문자 ID와 파라미터로 받은  유저 ID가 동일한지 확인해서 주문자 본인인지 확인
+		 *
+		 * 이 둘인 경우에만 진행  그 외엔 401
+		 */
+
+		Delivery delivery = getDelivery(deliveryId);
+
+		/**
+		 *  네이버 지도 API를 통해  address를 위경도로 변환하고 배송경로 생성
+		 *  double distance = api호출
+		 *  int duration = api 호출
+		 *  DistanceAndDuration updatedDistanceAndDuration = DistanceAndDuration.of(distance, duration);
+		 *
+		 *  그리고 아래 위경도에 가져온 값을 넣으면 됨
+		 */
+		Address updatedAddress = Address.of(requestDto.address(), 37.571, 126.976);
+
+		UUID companyDeliveryStaffId = assignDeliveryStaffService.assignCompanyDeliveryStaff(delivery.getDestinationHubId());
+		/**
+		 *   of 쓰기전 검증
+		 *   validateParamInCompanyDeliveryHistory(updatedDistanceAndDuration, companyDeliveryStaffId);
+ 		 */
+
+		/**
+		 *  새 업체배송경로에 저장
+		 *
+		 *   CompanyDeliveryHistory updatedHistory = CompanyDeliveryHistory.of(
+		 *   updatedAddress, updatedDistanceAndDuration, null, delivery.getCompanyDeliveryStaffId);
+		 *
+		 */
+
+		checkDeliveryStatus(delivery.getDeliveryStatusRecord().getDeliveryStatus());
+		delivery.update(updatedAddress, null, companyDeliveryStaffId);
+		// delivery.setCompanyDeliveryHistory(updatedHistory);
+
+		return new UpdateDeliveryResponseDto(
+			delivery.getId(),
+			delivery.getAddress().getFullAddress(),
+			delivery.getDeliveryStatusRecord().getDeliveryStatus().name(),
+			LocalDateTime.now());
+	}
+
+	private Delivery getDelivery(UUID deliveryId) {
+		return deliveryRepository.findById(deliveryId)
+			.orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));
+	}
+
+	private void validateParam(UUID hubDeliveryStaffId, UUID companyDeliveryStaffId, UUID receiverId, String receiverSlackId, UUID orderId) {
+		if (hubDeliveryStaffId == null) {
+			throw new CustomException(ErrorCode.INVALID_HUB_DELIVERY_STAFF_EMPTY_OR_NULL);
+		}
+		if (companyDeliveryStaffId == null) {
+			throw new CustomException(ErrorCode.INVALID_COMPANY_DELIVERY_STAFF_EMPTY_OR_NULL);
+		}
+		if (receiverId == null) {
+			throw new CustomException(ErrorCode.INVALID_RECEIVER_ID_NULL);
+		}
+		if (receiverSlackId == null) {
+			throw new CustomException(ErrorCode.INVALID_RECEIVER_SLACK_ID_NULL);
+		}
+		if (orderId == null) {
+			throw new CustomException(ErrorCode.INVALID_ORDER_ID_NULL);
+		}
+	}
+
+	private static void validateParamInCompanyDeliveryHistory(DistanceAndDuration expectedDistanceAndDuration, UUID companyDeliveryStaffId) {
+		if (expectedDistanceAndDuration == null) {
+			throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
+		}
+		if (companyDeliveryStaffId == null) {
+			throw new CustomException(ErrorCode.INVALID_COMPANY_DELIVERY_STAFF_EMPTY_OR_NULL);
+		}
+	}
+
+	private void checkDeliveryStatus(DeliveryStatus deliveryStatus) {
+		if (deliveryStatus != DeliveryStatus.ARRIVED_AT_DESTINATION_HUB &&
+			deliveryStatus != DeliveryStatus.BEFORE_DELIVERY_START) {
+			throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS);
+		}
 	}
 }

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryServiceImpl.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryServiceImpl.java
@@ -149,6 +149,17 @@ public class DeliveryServiceImpl implements DeliveryService{
 		return deliveryRepository.save(delivery);
 	}
 
+	@Override
+	public void cancelDelivery(UUID deliveryId) {
+		Delivery delivery = getDelivery(deliveryId);
+
+		String username = "빨리좀해라";
+
+		delivery.cancelDelivery(username);
+
+		deliveryRepository.save(delivery);
+	}
+
 	private Delivery getDelivery(UUID deliveryId) {
 		return deliveryRepository.findById(deliveryId)
 			.orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryServiceImpl.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryServiceImpl.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.example.delivery.application.dto.CreateDeliveryResponseDto;
 import com.example.delivery.application.dto.UpdateDeliveryResponseDto;
@@ -20,6 +19,7 @@ import com.example.delivery.libs.exception.ErrorCode;
 import com.example.delivery.presentation.dto.CreateDeliveryRequestDto;
 import com.example.delivery.presentation.dto.UpdateDeliveryRequestDto;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -125,6 +125,28 @@ public class DeliveryServiceImpl implements DeliveryService{
 			delivery.getAddress().getFullAddress(),
 			delivery.getDeliveryStatusRecord().getDeliveryStatus().name(),
 			LocalDateTime.now());
+	}
+
+	// @Override
+	// public UpdateDeliveryStatusResponseDto updateDeliveryStatus(UUID deliveryId) {
+	// 	Delivery delivery = getDelivery(deliveryId);
+	//
+	// 	delivery.updateDeliveryStatus();
+	//
+	// 	deliveryRepository.save(delivery);
+	//
+	// 	return new UpdateDeliveryStatusResponseDto(
+	// 		delivery.getId(),
+	// 		delivery.getDeliveryStatusRecord().getDeliveryStatus().name(),
+	// 		LocalDateTime.now());
+	// }
+	@Override
+	public Delivery updateDeliveryStatus(UUID deliveryId) {
+		Delivery delivery = getDelivery(deliveryId);
+
+		delivery.updateDeliveryStatus();
+
+		return deliveryRepository.save(delivery);
 	}
 
 	private Delivery getDelivery(UUID deliveryId) {

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryStatusUpdateService.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryStatusUpdateService.java
@@ -1,0 +1,11 @@
+package com.example.delivery.application.service;
+
+import java.util.UUID;
+
+import com.example.delivery.domain.model.entity.Delivery;
+
+public interface DeliveryStatusUpdateService {
+
+	Delivery updateDeliveryStatus(UUID deliveryId);
+
+}

--- a/delivery/src/main/java/com/example/delivery/application/service/DeliveryUpdateService.java
+++ b/delivery/src/main/java/com/example/delivery/application/service/DeliveryUpdateService.java
@@ -1,0 +1,12 @@
+package com.example.delivery.application.service;
+
+import java.util.UUID;
+
+import com.example.delivery.application.dto.UpdateDeliveryResponseDto;
+import com.example.delivery.presentation.dto.UpdateDeliveryRequestDto;
+
+public interface DeliveryUpdateService {
+
+	UpdateDeliveryResponseDto updateDelivery(UUID deliveryId, UpdateDeliveryRequestDto requestDto);
+
+}

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/CompanyDeliveryHistory.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/CompanyDeliveryHistory.java
@@ -4,8 +4,6 @@ import java.util.UUID;
 
 import com.example.delivery.domain.model.vo.Address;
 import com.example.delivery.domain.model.vo.DistanceAndDuration;
-import com.example.delivery.libs.exception.CustomException;
-import com.example.delivery.libs.exception.ErrorCode;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -68,9 +66,6 @@ public class CompanyDeliveryHistory {
 	public static CompanyDeliveryHistory of(Address address, DistanceAndDuration expectedDistanceAndDuration,
 		DistanceAndDuration distanceAndDuration, UUID companyDeliveryStaffId) {
 
-		// TODO: 이후 api 구현시 검증로직 서비스로 이동
-		validateParam(expectedDistanceAndDuration, companyDeliveryStaffId);
-
 		return CompanyDeliveryHistory.builder()
 			.address(address)
 			.expectedDistanceAndDuration(expectedDistanceAndDuration)
@@ -79,15 +74,6 @@ public class CompanyDeliveryHistory {
 			.build();
 	}
 
-	// TODO: 이후 api 구현시 검증로직 서비스로 이동
-	private static void validateParam(DistanceAndDuration expectedDistanceAndDuration, UUID companyDeliveryStaffId) {
-		if (expectedDistanceAndDuration == null) {
-			throw new CustomException(ErrorCode.INVALID_DISTANCE_OR_DURATION_IS_NOT_NULL);
-		}
-		if (companyDeliveryStaffId == null) {
-			throw new CustomException(ErrorCode.INVALID_COMPANY_DELIVERY_STAFF_EMPTY_OR_NULL);
-		}
-	}
 
 	public void setDeleted(String username) {
 		this.isDeleted = true;

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
@@ -154,6 +154,17 @@ public class Delivery {
 		}
 	}
 
+	public void cancelDelivery(String username) {
+		if (this.isCompleted) {
+			throw new CustomException(ErrorCode.ALREADY_COMPLETED_DELIVERY);
+		}
+
+		this.deliveryStatusRecord = this.deliveryStatusRecord.updateStatus(DeliveryStatus.DELIVERY_CANCELLED);
+		this.statusHistoryList.add(DeliveryStatusHistory.of(DeliveryStatus.DELIVERY_CANCELLED, this));
+
+		this.setDeleted(username);
+	}
+
 	public void setDeleted(String username) {
 		this.isDeleted = true;
 		this.deletedBy = username;
@@ -172,8 +183,6 @@ public class Delivery {
 			this.companyDeliveryHistory = companyDeliveryHistory;
 		}
 	}
-
-
 
 	private void removeExistingCompanyDelivery() {
 		if (this.companyDeliveryHistory != null) {

--- a/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/entity/Delivery.java
@@ -9,8 +9,6 @@ import java.util.UUID;
 import com.example.delivery.domain.model.enums.DeliveryStatus;
 import com.example.delivery.domain.model.vo.Address;
 import com.example.delivery.domain.model.vo.DeliveryStatusRecord;
-import com.example.delivery.libs.exception.CustomException;
-import com.example.delivery.libs.exception.ErrorCode;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -64,7 +62,7 @@ public class Delivery {
 	private UUID receiverId;
 
 	@Column(nullable = false)
-	private UUID receiverSlackId;
+	private String receiverSlackId;
 
 	@Column(nullable = false)
 	private UUID orderId;
@@ -90,7 +88,7 @@ public class Delivery {
 	@Builder
 	private Delivery(DeliveryStatusRecord deliveryStatusRecord, Address address,
 		UUID startHubId, UUID destinationHubId, UUID hubDeliveryStaffId, UUID companyDeliveryStaffId,
-		UUID receiverId, UUID receiverSlackId, UUID orderId, UUID hubDeliveryHistoryId,
+		UUID receiverId, String receiverSlackId, UUID orderId, UUID hubDeliveryHistoryId,
 		CompanyDeliveryHistory companyDeliveryHistory) {
 		this.deliveryStatusRecord = deliveryStatusRecord;
 		this.address = address;
@@ -107,11 +105,8 @@ public class Delivery {
 
 	public static Delivery of(DeliveryStatusRecord deliveryStatusRecord, Address address,
 		UUID startHubId, UUID destinationHubId, UUID hubDeliveryStaffId, UUID companyDeliveryStaffId,
-		UUID receiverId, UUID receiverSlackId, UUID orderId, UUID hubDeliveryHistoryId,
+		UUID receiverId, String receiverSlackId, UUID orderId, UUID hubDeliveryHistoryId,
 		CompanyDeliveryHistory companyDeliveryHistory) {
-
-		// TODO: 이후 api 구현시 검증로직 서비스로 이동
-		validateParam(hubDeliveryStaffId, companyDeliveryStaffId, receiverId, receiverSlackId, orderId);
 
 		Delivery delivery = Delivery.builder()
 			.deliveryStatusRecord(deliveryStatusRecord)
@@ -132,26 +127,6 @@ public class Delivery {
 		);
 
 		return delivery;
-	}
-
-	// TODO: 이후 api 구현시 검증로직 서비스로 이동
-	private static void validateParam(UUID hubDeliveryStaffId, UUID companyDeliveryStaffId, UUID receiverId, UUID receiverSlackId, UUID orderId) {
-
-		if (hubDeliveryStaffId == null) {
-			throw new CustomException(ErrorCode.INVALID_HUB_DELIVERY_STAFF_EMPTY_OR_NULL);
-		}
-		if (companyDeliveryStaffId == null) {
-			throw new CustomException(ErrorCode.INVALID_COMPANY_DELIVERY_STAFF_EMPTY_OR_NULL);
-		}
-		if (receiverId == null) {
-			throw new CustomException(ErrorCode.INVALID_RECEIVER_ID_NULL);
-		}
-		if (receiverSlackId == null) {
-			throw new CustomException(ErrorCode.INVALID_RECEIVER_SLACK_ID_NULL);
-		}
-		if (orderId == null) {
-			throw new CustomException(ErrorCode.INVALID_ORDER_ID_NULL);
-		}
 	}
 
 	public void update(Address address, UUID hubDeliveryStaffId, UUID companyDeliveryStaffId) {
@@ -177,9 +152,6 @@ public class Delivery {
 	 * 혹시 모를 잔여 데이터 제거
 	 */
 	public void setCompanyDeliveryHistory(CompanyDeliveryHistory companyDeliveryHistory) {
-		// TODO: 이후 api 구현시 검증로직 서비스로 이동
-		checkDeliveryStatus();
-
 		removeExistingCompanyDelivery();
 
 		if (companyDeliveryHistory != null) {
@@ -187,13 +159,7 @@ public class Delivery {
 		}
 	}
 
-	// TODO: 이후 api 구현시 검증로직 서비스로 이동
-	private void checkDeliveryStatus() {
-		if (this.deliveryStatusRecord.getDeliveryStatus() != DeliveryStatus.ARRIVED_AT_DESTINATION_HUB &&
-			this.deliveryStatusRecord.getDeliveryStatus() != DeliveryStatus.BEFORE_DELIVERY_START) {
-			throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS);
-		}
-	}
+
 
 	private void removeExistingCompanyDelivery() {
 		if (this.companyDeliveryHistory != null) {

--- a/delivery/src/main/java/com/example/delivery/domain/model/enums/DeliveryStatus.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/enums/DeliveryStatus.java
@@ -15,26 +15,36 @@ public enum DeliveryStatus {
 
 	DELIVERY_CANCELLED;
 
-	public boolean canChangeStatus(DeliveryStatus nextStatus) {
-		switch (this) {
-			case WAITING_IN_START_HUB -> {
-				return nextStatus == MOVING_TO_DESTINATION_HUB;
-			}
-			case MOVING_TO_DESTINATION_HUB -> {
-				return nextStatus == ARRIVED_AT_DESTINATION_HUB;
-			}
-			case ARRIVED_AT_DESTINATION_HUB -> {
-				return nextStatus == BEFORE_DELIVERY_START || nextStatus == DELIVERY_CANCELLED;
-			}
-			case BEFORE_DELIVERY_START -> {
-				return nextStatus == DELIVERY_IN_PROGRESS || nextStatus == DELIVERY_CANCELLED;
-			}
-			case DELIVERY_IN_PROGRESS -> {
-				return nextStatus == DELIVERY_COMPLETED || nextStatus == DELIVERY_CANCELLED;
-			}
-			default -> {
-				throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
-			}
-		}
+	public DeliveryStatus changeNextStatus() {
+		return switch (this) {
+			case WAITING_IN_START_HUB -> MOVING_TO_DESTINATION_HUB;
+			case MOVING_TO_DESTINATION_HUB -> ARRIVED_AT_DESTINATION_HUB;
+			case ARRIVED_AT_DESTINATION_HUB -> BEFORE_DELIVERY_START;
+			case BEFORE_DELIVERY_START -> DELIVERY_IN_PROGRESS;
+			case DELIVERY_IN_PROGRESS -> DELIVERY_COMPLETED;
+			default -> throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
+		};
 	}
+	// public boolean canChangeStatus(DeliveryStatus nextStatus) {
+	// 	switch (this) {
+	// 		case WAITING_IN_START_HUB -> {
+	// 			return nextStatus == MOVING_TO_DESTINATION_HUB;
+	// 		}
+	// 		case MOVING_TO_DESTINATION_HUB -> {
+	// 			return nextStatus == ARRIVED_AT_DESTINATION_HUB;
+	// 		}
+	// 		case ARRIVED_AT_DESTINATION_HUB -> {
+	// 			return nextStatus == BEFORE_DELIVERY_START || nextStatus == DELIVERY_CANCELLED;
+	// 		}
+	// 		case BEFORE_DELIVERY_START -> {
+	// 			return nextStatus == DELIVERY_IN_PROGRESS || nextStatus == DELIVERY_CANCELLED;
+	// 		}
+	// 		case DELIVERY_IN_PROGRESS -> {
+	// 			return nextStatus == DELIVERY_COMPLETED || nextStatus == DELIVERY_CANCELLED;
+	// 		}
+	// 		default -> {
+	// 			throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
+	// 		}
+	// 	}
+	// }
 }

--- a/delivery/src/main/java/com/example/delivery/domain/model/vo/DeliveryStatusRecord.java
+++ b/delivery/src/main/java/com/example/delivery/domain/model/vo/DeliveryStatusRecord.java
@@ -1,5 +1,7 @@
 package com.example.delivery.domain.model.vo;
 
+import java.time.LocalDateTime;
+
 import com.example.delivery.domain.model.enums.DeliveryStatus;
 import com.example.delivery.libs.exception.CustomException;
 import com.example.delivery.libs.exception.ErrorCode;
@@ -13,8 +15,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.LocalDateTime;
 
 @Embeddable
 @Slf4j
@@ -37,10 +37,7 @@ public class DeliveryStatusRecord {
 
 	public DeliveryStatusRecord updateStatus(DeliveryStatus updatedDeliveryStatus) {
 		validate(updatedDeliveryStatus);
-		if (!this.deliveryStatus.canChangeStatus(updatedDeliveryStatus)) {
-			log.info("변경 실패 : currentStatus={}, nextStatus={}", this.deliveryStatus, updatedDeliveryStatus);
-			throw new CustomException(ErrorCode.INVALID_DELIVERY_STATUS_CHANGE);
-		}
+		log.info("해당 상태로 변경 : parameterStatus={}", updatedDeliveryStatus);
 		return new DeliveryStatusRecord(updatedDeliveryStatus, LocalDateTime.now());
 	}
 

--- a/delivery/src/main/java/com/example/delivery/infrastructure/config/RabbitMQConfig.java
+++ b/delivery/src/main/java/com/example/delivery/infrastructure/config/RabbitMQConfig.java
@@ -1,0 +1,59 @@
+package com.example.delivery.infrastructure.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+	public static final String DELIVERY_STATUS_ROUTING_KEY = "delivery.status";
+	public static final String DELIVERY_STATUS_QUEUE = "delivery.status.queue";
+	public static final String EXCHANGE = "delivery.status.exchange";
+
+
+	@Bean
+	public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+		RabbitTemplate template = new RabbitTemplate(connectionFactory);
+		template.setMessageConverter(jackson2JsonMessageConverter());
+		return template;
+	}
+
+	@Bean
+	public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+
+	@Bean
+	public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory connectionFactory) {
+		SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+		factory.setConnectionFactory(connectionFactory);
+		factory.setMessageConverter(jackson2JsonMessageConverter());
+		return factory;
+	}
+
+	@Bean
+	public TopicExchange deliveryExchange() {
+		return new TopicExchange(EXCHANGE);
+	}
+
+	@Bean
+	public Queue deliveryStatusQueue() {
+		return new Queue(DELIVERY_STATUS_QUEUE, true);
+	}
+
+	@Bean
+	public Binding deliveryStatusBinding(Queue deliveryStatusQueue, TopicExchange deliveryExchange) {
+		return BindingBuilder
+			.bind(deliveryStatusQueue)
+			.to(deliveryExchange)
+			.with(DELIVERY_STATUS_ROUTING_KEY);
+	}
+}

--- a/delivery/src/main/java/com/example/delivery/infrastructure/event/DeliveryStatusMessage.java
+++ b/delivery/src/main/java/com/example/delivery/infrastructure/event/DeliveryStatusMessage.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record DeliveryStatusMessage(
+	String receiverSlackId,
 	UUID deliveryId,
 	String updatedStatus,
 	LocalDateTime updatedAt

--- a/delivery/src/main/java/com/example/delivery/infrastructure/event/DeliveryStatusMessage.java
+++ b/delivery/src/main/java/com/example/delivery/infrastructure/event/DeliveryStatusMessage.java
@@ -1,0 +1,11 @@
+package com.example.delivery.infrastructure.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record DeliveryStatusMessage(
+	UUID deliveryId,
+	String updatedStatus,
+	LocalDateTime updatedAt
+) {
+}

--- a/delivery/src/main/java/com/example/delivery/infrastructure/messaging/DeliveryStatusPublisher.java
+++ b/delivery/src/main/java/com/example/delivery/infrastructure/messaging/DeliveryStatusPublisher.java
@@ -17,8 +17,8 @@ public class DeliveryStatusPublisher {
 
 	private final RabbitTemplate rabbitTemplate;
 
-	public void publish(UUID deliveryId, String updatedStatus, LocalDateTime updatedAt) {
-		DeliveryStatusMessage message = new DeliveryStatusMessage(deliveryId, updatedStatus, updatedAt);
+	public void publish(String receiverSlackId, UUID deliveryId, String updatedStatus, LocalDateTime updatedAt) {
+		DeliveryStatusMessage message = new DeliveryStatusMessage(receiverSlackId, deliveryId, updatedStatus, updatedAt);
 
 		rabbitTemplate.convertAndSend(RabbitMQConfig.EXCHANGE, RabbitMQConfig.DELIVERY_STATUS_ROUTING_KEY, message);
 	}

--- a/delivery/src/main/java/com/example/delivery/infrastructure/messaging/DeliveryStatusPublisher.java
+++ b/delivery/src/main/java/com/example/delivery/infrastructure/messaging/DeliveryStatusPublisher.java
@@ -1,0 +1,25 @@
+package com.example.delivery.infrastructure.messaging;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import com.example.delivery.infrastructure.config.RabbitMQConfig;
+import com.example.delivery.infrastructure.event.DeliveryStatusMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryStatusPublisher {
+
+	private final RabbitTemplate rabbitTemplate;
+
+	public void publish(UUID deliveryId, String updatedStatus, LocalDateTime updatedAt) {
+		DeliveryStatusMessage message = new DeliveryStatusMessage(deliveryId, updatedStatus, updatedAt);
+
+		rabbitTemplate.convertAndSend(RabbitMQConfig.EXCHANGE, RabbitMQConfig.DELIVERY_STATUS_ROUTING_KEY, message);
+	}
+}

--- a/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
+++ b/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 	INVALID_DELIVERY_STATUS_CHANGE(400, "유효하지않은 배송상태입니다."),
 	INVALID_LATITUDE(400, "유효하지않은 위도입니다. 대한민국의 위도는 북쪽 약 38.5  남쪽 약 33.0의 위도 내에 위치해야 합니다."),
 	INVALID_LONGITUDE(400, "유효하지않은 경도입니다. 대한민국의 경도는 서쪽 약 124.0  동쪽 약 132.0의 위도 내에 위치해야 합니다."),
+	ALREADY_COMPLETED_DELIVERY(400, "이미 배송완료상태입니다.  상태를 변경할 수 없습니다."),
 
 	/*  401 UNAUTHORIZED : 인증 안됨  */
 	UNAUTHORIZED(401, "인증되지 않았습니다."),

--- a/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
+++ b/delivery/src/main/java/com/example/delivery/libs/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 	PRODUCT_NOT_FOUND(404, "상품을 찾을 수 없습니다."),
 	HUB_DELIVERY_STAFF_NOT_FOUND(404, "허브 배송담당자를 찾을 수 없습니다."),
 	COMPANY_DELIVERY_STAFF_NOT_FOUND(404, "업체 배송담당자를 찾을 수 없습니다."),
+	DELIVERY_NOT_FOUND(404, "해당 배송을 찾을 수 없습니다."),
 
 	/*  408 REQUEST_TIMEOUT : 요청에 대한 응답 시간 초과  */
 	TIMEOUT_ERROR(408, "응답시간을 초과하였습니다."),

--- a/delivery/src/main/java/com/example/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/controller/DeliveryController.java
@@ -1,15 +1,21 @@
 package com.example.delivery.presentation.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.delivery.application.dto.CreateDeliveryResponseDto;
+import com.example.delivery.application.dto.UpdateDeliveryResponseDto;
 import com.example.delivery.application.service.DeliveryService;
 import com.example.delivery.presentation.dto.CreateDeliveryRequestDto;
+import com.example.delivery.presentation.dto.UpdateDeliveryRequestDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,5 +37,19 @@ public class DeliveryController {
 			requestDto
 		);
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+	}
+
+	@PatchMapping("/{deliveryId}")
+	public ResponseEntity<UpdateDeliveryResponseDto> updateDelivery(
+		// @RequestHeader("X-User-Id") Long userId,
+		// @RequestHeader("X-User-Role") String userRole,
+		@PathVariable UUID deliveryId,
+		@RequestBody UpdateDeliveryRequestDto requestDto
+	) {
+		UpdateDeliveryResponseDto responseDto = deliveryService.updateDelivery(deliveryId,
+		// userId, userRole,
+			requestDto
+		);
+		return ResponseEntity.ok(responseDto);
 	}
 }

--- a/delivery/src/main/java/com/example/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/controller/DeliveryController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,5 +64,15 @@ public class DeliveryController {
 	) {
 		deliveryFacadeService.updateDeliveryStatusAndNotifyToSlack(deliveryId);
 		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/{deliveryId}")
+	public ResponseEntity<Void> cancelDelivery(
+		// @RequestHeader("X-User-Id") Long userId,
+		// @RequestHeader("X-User-Role") String userRole,
+		@PathVariable UUID deliveryId
+	) {
+		deliveryService.cancelDelivery(deliveryId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/delivery/src/main/java/com/example/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/controller/DeliveryController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.delivery.application.dto.CreateDeliveryResponseDto;
 import com.example.delivery.application.dto.UpdateDeliveryResponseDto;
+import com.example.delivery.application.service.DeliveryFacadeService;
 import com.example.delivery.application.service.DeliveryService;
 import com.example.delivery.presentation.dto.CreateDeliveryRequestDto;
 import com.example.delivery.presentation.dto.UpdateDeliveryRequestDto;
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class DeliveryController {
 
 	private final DeliveryService deliveryService;
+	private final DeliveryFacadeService deliveryFacadeService;
 
 	@PostMapping
 	public ResponseEntity<CreateDeliveryResponseDto> createDelivery(
@@ -51,5 +53,15 @@ public class DeliveryController {
 			requestDto
 		);
 		return ResponseEntity.ok(responseDto);
+	}
+
+	@PatchMapping("/{deliveryId}/status")
+	public ResponseEntity<Void> updateDeliveryStatus(
+		// @RequestHeader("X-User-Id") Long userId,
+		// @RequestHeader("X-User-Role") String userRole,
+		@PathVariable UUID deliveryId
+	) {
+		deliveryFacadeService.updateDeliveryStatusAndNotifyToSlack(deliveryId);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/delivery/src/main/java/com/example/delivery/presentation/dto/CreateDeliveryRequestDto.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/dto/CreateDeliveryRequestDto.java
@@ -2,21 +2,21 @@ package com.example.delivery.presentation.dto;
 
 import java.util.UUID;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record CreateDeliveryRequestDto(
-	@NotNull(message = "주문 ID는 필수입니다.")
+	@NotBlank(message = "주문 ID는 필수입니다.")
 	UUID orderId,
-	@NotNull(message = "허브배송경로 조회를 위해 출발지 허브 ID는 필수입니다.")
+	@NotBlank(message = "허브배송경로 조회를 위해 출발지 허브 ID는 필수입니다.")
 	UUID startHubId,
-	@NotNull(message = "허브배송경로 조회를 위해 도착지 허브 ID는 필수입니다.")
+	@NotBlank(message = "허브배송경로 조회를 위해 도착지 허브 ID는 필수입니다.")
 	UUID destinationHubId,
-	@NotNull(message = "수령인 ID는 필수입니다.")
+	@NotBlank(message = "수령인 ID는 필수입니다.")
 	UUID receiverId,
-	@NotNull(message = "슬랙 메세지 발송을 위해 수령인 슬랙 ID는 필수입니다.")
-	UUID receiverSlackId,
-	@NotNull(message = "주소는 필수입니다.")
+	@NotBlank(message = "슬랙 메세지 발송을 위해 수령인 슬랙 ID는 필수입니다.")
+	String receiverSlackId,
+	@NotBlank(message = "주소는 필수입니다.")
 	@Pattern(
 		regexp = "^([가-힣]+(특별시|광역시|도))\\s([가-힣]+(시|군|구))\\s(.+)$",
 		message = "주소 입력 양식은 다음과 같습니다. 예: 서울특별시 강남구 선릉로 100길 1"

--- a/delivery/src/main/java/com/example/delivery/presentation/dto/UpdateDeliveryRequestDto.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/dto/UpdateDeliveryRequestDto.java
@@ -1,6 +1,14 @@
 package com.example.delivery.presentation.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record UpdateDeliveryRequestDto(
+	@NotBlank(message = "주소는 필수입니다.")
+	@Pattern(
+		regexp = "^([가-힣]+(특별시|광역시|도))\\s([가-힣]+(시|군|구))\\s(.+)$",
+		message = "주소 입력 양식은 다음과 같습니다. 예: 서울특별시 강남구 선릉로 100길 1"
+	)
 	String address
 
 ) {

--- a/delivery/src/main/java/com/example/delivery/presentation/dto/UpdateDeliveryRequestDto.java
+++ b/delivery/src/main/java/com/example/delivery/presentation/dto/UpdateDeliveryRequestDto.java
@@ -1,0 +1,7 @@
+package com.example.delivery.presentation.dto;
+
+public record UpdateDeliveryRequestDto(
+	String address
+
+) {
+}

--- a/delivery/src/main/resources/application-dev.yml
+++ b/delivery/src/main/resources/application-dev.yml
@@ -2,6 +2,15 @@ spring:
   application:
     name: delivery
 
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+    listener:
+      simple:
+        auto-startup: false
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
#23 
#25 
#26 

update 는  배송주소를 수정하는 로직을 구현

status update는 api 실행 시 자동으로 다음 배송단계로 넘어가며
배송단계 별로 메서드 실행 순간의 시간을 저장하여 히스토리로 기록
또한 메세지큐와 연계하여  배송상태가 변경될 때마다 수령인에게 슬랙메세지를 보낼 수 있도록 함

delete는 소프트딜리트이며,  배송상태를 cancelled 로 변경하는 로직이 함께 동작

<br>
토요일 오후 4시에 머지하겠습니다.