### PR TITLE
Feat/deliverystaff

### DIFF
--- a/auth/src/main/java/com/example/auth/application/dto/DeliveryStaffResponseDto.java
+++ b/auth/src/main/java/com/example/auth/application/dto/DeliveryStaffResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.auth.application.dto;
+
+import java.util.UUID;
+
+import com.example.auth.domain.model.enums.DeliveryType;
+
+public record DeliveryStaffResponseDto(
+
+	UUID id,
+	String username,
+	DeliveryType deliveryType,
+	UUID hubId
+) {
+}

--- a/auth/src/main/java/com/example/auth/application/service/DeliveryStaffService.java
+++ b/auth/src/main/java/com/example/auth/application/service/DeliveryStaffService.java
@@ -1,10 +1,14 @@
 package com.example.auth.application.service;
 
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.auth.domain.model.entity.DeliveryStaff;
 import com.example.auth.domain.model.entity.User;
+import com.example.auth.domain.model.enums.DeliveryType;
 import com.example.auth.domain.model.vo.Username;
 import com.example.auth.domain.repository.AuthRepository;
 import com.example.auth.domain.repository.DeliveryStaffRepository;
@@ -22,12 +26,21 @@ public class DeliveryStaffService {
 	private final AuthRepository authRepository;
 
 	@Transactional
-	public void registerDeliveryStaff(DeliveryStaffRegisterRequestDto requestDto) {
+	public void registerDeliveryStaff(DeliveryStaffRegisterRequestDto requestDto, String userRole) {
+		checkUserRole(userRole);
+
 		User user = getUser(requestDto);
+
+		int hubDeliveryStaffCount = countHubDeliveryStaff();
+		checkHubDeliveryStaffCount(hubDeliveryStaffCount);
+
+		int companyDeliveryStaffCount = countCompanyDeliveryStaff(requestDto);
+		checkCompanyDeliveryStaffCount(companyDeliveryStaffCount);
 
 		if (deliveryStaffRepository.existsByUserId(user.getId())) {
 			throw new CustomException(ErrorCode.ALREADY_REGISTERED_DELIVERY_STAFF);
 		}
+
 		DeliveryStaff deliveryStaff = DeliveryStaff.builder()
 			.userId(user.getId())
 			.username(requestDto.username())
@@ -37,6 +50,49 @@ public class DeliveryStaffService {
 			.build();
 
 		deliveryStaffRepository.save(deliveryStaff);
+	}
+
+	@Transactional(readOnly = true)
+	public List<UUID> getHubDeliveryStaffList() {
+		return deliveryStaffRepository.findByDeliveryType(DeliveryType.HUB_DELIVERY_STAFF)
+			.stream()
+			.map(DeliveryStaff::getId)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<UUID> getCompanyDeliveryStaffList(UUID hubId) {
+		return deliveryStaffRepository.findByDeliveryTypeAndHubId(DeliveryType.COMPANY_DELIVERY_STAFF, hubId)
+			.stream()
+			.map(DeliveryStaff::getId)
+			.toList();
+	}
+
+	private static void checkUserRole(String userRole) {
+		if (!"MASTER".equals(userRole)) {
+			throw new CustomException(ErrorCode.UNAUTHORIZED);
+		}
+	}
+
+	private int countHubDeliveryStaff() {
+		return deliveryStaffRepository.countByDeliveryType(DeliveryType.HUB_DELIVERY_STAFF);
+	}
+
+	private static void checkHubDeliveryStaffCount(int hubDeliveryStaffCount) {
+		if (hubDeliveryStaffCount >= 10) {
+			throw new CustomException(ErrorCode.NO_ROOM_FOR_HUB_DELIVERY_STAFF);
+		}
+	}
+
+	private static void checkCompanyDeliveryStaffCount(int companyDeliveryStaffCount) {
+		if (companyDeliveryStaffCount >= 10) {
+			throw new CustomException(ErrorCode.NO_ROOM_FOR_COMPANY_DELIVERY_STAFF);
+		}
+	}
+
+	private int countCompanyDeliveryStaff(DeliveryStaffRegisterRequestDto requestDto) {
+		return deliveryStaffRepository.countByDeliveryTypeAndHubId(requestDto.deliveryType(),
+			requestDto.hubId());
 	}
 
 	private User getUser(DeliveryStaffRegisterRequestDto requestDto) {

--- a/auth/src/main/java/com/example/auth/application/service/DeliveryStaffService.java
+++ b/auth/src/main/java/com/example/auth/application/service/DeliveryStaffService.java
@@ -68,6 +68,14 @@ public class DeliveryStaffService {
 			.toList();
 	}
 
+	@Transactional
+	public void deleteDeliveryStaff(UUID deliveryStaffId) {
+		DeliveryStaff deliveryStaff = getDeliveryStaff(deliveryStaffId);
+
+		deliveryStaff.setDeleted();
+		deliveryStaffRepository.save(deliveryStaff);
+	}
+
 	private static void checkUserRole(String userRole) {
 		if (!"MASTER".equals(userRole)) {
 			throw new CustomException(ErrorCode.UNAUTHORIZED);
@@ -98,5 +106,10 @@ public class DeliveryStaffService {
 	private User getUser(DeliveryStaffRegisterRequestDto requestDto) {
 		return authRepository.findByUsername(Username.of(requestDto.username()))
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+	}
+
+	private DeliveryStaff getDeliveryStaff(UUID deliveryStaffId) {
+		return deliveryStaffRepository.findById(deliveryStaffId)
+			.orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_STAFF_NOT_FOUND));
 	}
 }

--- a/auth/src/main/java/com/example/auth/application/service/DeliveryStaffService.java
+++ b/auth/src/main/java/com/example/auth/application/service/DeliveryStaffService.java
@@ -1,0 +1,46 @@
+package com.example.auth.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.auth.domain.model.entity.DeliveryStaff;
+import com.example.auth.domain.model.entity.User;
+import com.example.auth.domain.model.vo.Username;
+import com.example.auth.domain.repository.AuthRepository;
+import com.example.auth.domain.repository.DeliveryStaffRepository;
+import com.example.auth.libs.exception.CustomException;
+import com.example.auth.libs.exception.ErrorCode;
+import com.example.auth.presentation.dto.DeliveryStaffRegisterRequestDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryStaffService {
+
+	private final DeliveryStaffRepository deliveryStaffRepository;
+	private final AuthRepository authRepository;
+
+	@Transactional
+	public void registerDeliveryStaff(DeliveryStaffRegisterRequestDto requestDto) {
+		User user = getUser(requestDto);
+
+		if (deliveryStaffRepository.existsByUserId(user.getId())) {
+			throw new CustomException(ErrorCode.ALREADY_REGISTERED_DELIVERY_STAFF);
+		}
+		DeliveryStaff deliveryStaff = DeliveryStaff.builder()
+			.userId(user.getId())
+			.username(requestDto.username())
+			.slackId(requestDto.slackId())
+			.deliveryType(requestDto.deliveryType())
+			.hubId(requestDto.hubId())
+			.build();
+
+		deliveryStaffRepository.save(deliveryStaff);
+	}
+
+	private User getUser(DeliveryStaffRegisterRequestDto requestDto) {
+		return authRepository.findByUsername(Username.of(requestDto.username()))
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+	}
+}

--- a/auth/src/main/java/com/example/auth/domain/model/entity/DeliveryStaff.java
+++ b/auth/src/main/java/com/example/auth/domain/model/entity/DeliveryStaff.java
@@ -1,0 +1,63 @@
+package com.example.auth.domain.model.entity;
+
+import java.util.UUID;
+
+import com.example.auth.domain.model.enums.DeliveryType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryStaff {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column(nullable = false, unique = true)
+	private UUID userId;
+
+	@Column(nullable = false)
+	private String username;
+
+	@Column(nullable = false)
+	private String slackId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private DeliveryType deliveryType;
+
+	private UUID hubId;
+
+	public boolean isHubDeliveryStaff() {
+		return this.deliveryType == DeliveryType.HUB_DELIVERY_STAFF;
+	}
+
+	public boolean isCompanyDeliveryStaff() {
+		return this.deliveryType == DeliveryType.COMPANY_DELIVERY_STAFF;
+	}
+
+	@Builder
+	public DeliveryStaff(UUID userId, String username, String slackId, DeliveryType deliveryType, UUID hubId) {
+		this.userId = userId;
+		this.username = username;
+		this.slackId = slackId;
+		this.deliveryType = deliveryType;
+		this.hubId = hubId;
+	}
+
+
+}

--- a/auth/src/main/java/com/example/auth/domain/model/entity/DeliveryStaff.java
+++ b/auth/src/main/java/com/example/auth/domain/model/entity/DeliveryStaff.java
@@ -59,5 +59,9 @@ public class DeliveryStaff {
 		this.hubId = hubId;
 	}
 
+	public void setDeleted() {
+		this.deliveryType = DeliveryType.DEACTIVATE;
+	}
+
 
 }

--- a/auth/src/main/java/com/example/auth/domain/model/enums/DeliveryType.java
+++ b/auth/src/main/java/com/example/auth/domain/model/enums/DeliveryType.java
@@ -1,0 +1,8 @@
+package com.example.auth.domain.model.enums;
+
+public enum DeliveryType {
+
+	HUB_DELIVERY_STAFF,
+	COMPANY_DELIVERY_STAFF
+
+}

--- a/auth/src/main/java/com/example/auth/domain/model/enums/DeliveryType.java
+++ b/auth/src/main/java/com/example/auth/domain/model/enums/DeliveryType.java
@@ -3,6 +3,7 @@ package com.example.auth.domain.model.enums;
 public enum DeliveryType {
 
 	HUB_DELIVERY_STAFF,
-	COMPANY_DELIVERY_STAFF
+	COMPANY_DELIVERY_STAFF,
+	DEACTIVATE
 
 }

--- a/auth/src/main/java/com/example/auth/domain/model/enums/UserRole.java
+++ b/auth/src/main/java/com/example/auth/domain/model/enums/UserRole.java
@@ -2,7 +2,6 @@ package com.example.auth.domain.model.enums;
 
 public enum UserRole {
 	USER,
-	HUB_DELIVERY_STAFF,
-	COMPANY_DELIVERY_STAFF,
+	DELIVERY_STAFF,
 	MASTER
 }

--- a/auth/src/main/java/com/example/auth/domain/repository/DeliveryStaffRepository.java
+++ b/auth/src/main/java/com/example/auth/domain/repository/DeliveryStaffRepository.java
@@ -1,0 +1,11 @@
+package com.example.auth.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.auth.domain.model.entity.DeliveryStaff;
+
+public interface DeliveryStaffRepository extends JpaRepository<DeliveryStaff, UUID> {
+	boolean existsByUserId(UUID id);
+}

--- a/auth/src/main/java/com/example/auth/domain/repository/DeliveryStaffRepository.java
+++ b/auth/src/main/java/com/example/auth/domain/repository/DeliveryStaffRepository.java
@@ -1,11 +1,26 @@
 package com.example.auth.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import com.example.auth.domain.model.entity.DeliveryStaff;
+import com.example.auth.domain.model.enums.DeliveryType;
+
+import jakarta.persistence.LockModeType;
 
 public interface DeliveryStaffRepository extends JpaRepository<DeliveryStaff, UUID> {
 	boolean existsByUserId(UUID id);
+
+	List<DeliveryStaff> findByDeliveryTypeAndHubId(DeliveryType deliveryType, UUID hubId);
+
+	List<DeliveryStaff> findByDeliveryType(DeliveryType deliveryType);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	int countByDeliveryType(DeliveryType deliveryType);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	int countByDeliveryTypeAndHubId(DeliveryType deliveryType, UUID uuid);
 }

--- a/auth/src/main/java/com/example/auth/infrastructure/config/AuthConfig.java
+++ b/auth/src/main/java/com/example/auth/infrastructure/config/AuthConfig.java
@@ -18,6 +18,7 @@ public class AuthConfig {
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers("/api/auth/signIn", "/api/auth/signUp", "/api/auth/").permitAll()
+				.requestMatchers("/api/delivery-staff/**").permitAll()
 				.requestMatchers("/api/auth/validate/**").permitAll()
 				.anyRequest().denyAll()
 			)

--- a/auth/src/main/java/com/example/auth/infrastructure/config/AuthConfig.java
+++ b/auth/src/main/java/com/example/auth/infrastructure/config/AuthConfig.java
@@ -18,7 +18,7 @@ public class AuthConfig {
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers("/api/auth/signIn", "/api/auth/signUp", "/api/auth/").permitAll()
-				.requestMatchers("/api/delivery-staff/**").permitAll()
+				.requestMatchers("/api/delivery-staffs/**").permitAll()
 				.requestMatchers("/api/auth/validate/**").permitAll()
 				.anyRequest().denyAll()
 			)

--- a/auth/src/main/java/com/example/auth/libs/exception/ErrorCode.java
+++ b/auth/src/main/java/com/example/auth/libs/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 	/*  404 NOT_FOUND : Resource 권한 없음, Resource 를 찾을 수 없음  */
 	ACCESS_DENIED(404, "접근 권한이 없습니다."),
 	USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
+	DELIVERY_STAFF_NOT_FOUND(404, "배송담당자를 찾을 수 없습니다."),
 
 	/*  408 REQUEST_TIMEOUT : 요청에 대한 응답 시간 초과  */
 	TIMEOUT_ERROR(408, "응답시간을 초과하였습니다."),

--- a/auth/src/main/java/com/example/auth/libs/exception/ErrorCode.java
+++ b/auth/src/main/java/com/example/auth/libs/exception/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
 	INVALID_PASSWORD_TYPE(400, "비밀번호는 소문자 영어 또는 숫자만 가능합니다."),
 	PASSWORD_DOES_NOT_MATCH(400, "비밀번호가 일치하지 않습니다."),
 	ALREADY_REGISTERED_DELIVERY_STAFF(400, "이미 등록된 배송 담당자입니다."),
+	INVALID_PARAMETER(400, "파라미터 값이 제공되어야합니다."),
+	NO_ROOM_FOR_HUB_DELIVERY_STAFF(400, "허브배송담당자를 더이상 추가할 수 없습니다."),
+	NO_ROOM_FOR_COMPANY_DELIVERY_STAFF(400, "업체배송담당자를 더이상 추가할 수 없습니다."),
 
 	/*  401 UNAUTHORIZED : 인증 안됨  */
 	UNAUTHORIZED(401, "인증되지 않았습니다."),

--- a/auth/src/main/java/com/example/auth/libs/exception/ErrorCode.java
+++ b/auth/src/main/java/com/example/auth/libs/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 	INVALID_USERNAME_TYPE(400, "유저네임은 소문자 영어 또는 숫자만 가능합니다."),
 	INVALID_PASSWORD_TYPE(400, "비밀번호는 소문자 영어 또는 숫자만 가능합니다."),
 	PASSWORD_DOES_NOT_MATCH(400, "비밀번호가 일치하지 않습니다."),
+	ALREADY_REGISTERED_DELIVERY_STAFF(400, "이미 등록된 배송 담당자입니다."),
 
 	/*  401 UNAUTHORIZED : 인증 안됨  */
 	UNAUTHORIZED(401, "인증되지 않았습니다."),

--- a/auth/src/main/java/com/example/auth/presentation/controller/DeliveryStaffController.java
+++ b/auth/src/main/java/com/example/auth/presentation/controller/DeliveryStaffController.java
@@ -1,9 +1,15 @@
 package com.example.auth.presentation.controller;
 
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,16 +21,30 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/delivery-staff")
+@RequestMapping("/api/delivery-staffs")
 public class DeliveryStaffController {
 
 	private final DeliveryStaffService deliveryStaffService;
 
 	@PostMapping("/register")
 	public ResponseEntity<String> registerDeliveryStaff(
+		@RequestHeader("X-User-Role") String userRole,
 		@RequestBody @Valid DeliveryStaffRegisterRequestDto requestDto) {
-		deliveryStaffService.registerDeliveryStaff(requestDto);
+		deliveryStaffService.registerDeliveryStaff(requestDto, userRole);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body("배송 담당자 등록 완료");
+	}
+
+	@GetMapping("/hub")
+	public ResponseEntity<List<UUID>> getHubDeliveryStaffList() {
+		List<UUID> responseDtoList = deliveryStaffService.getHubDeliveryStaffList();
+		return ResponseEntity.ok(responseDtoList);
+	}
+	@GetMapping("/{hubId}")
+	public ResponseEntity<List<UUID>> getCompanyDeliveryStaffList(
+		@PathVariable UUID hubId
+	) {
+		List<UUID> responseDtoList = deliveryStaffService.getCompanyDeliveryStaffList(hubId);
+		return ResponseEntity.ok(responseDtoList);
 	}
 }

--- a/auth/src/main/java/com/example/auth/presentation/controller/DeliveryStaffController.java
+++ b/auth/src/main/java/com/example/auth/presentation/controller/DeliveryStaffController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,5 +47,13 @@ public class DeliveryStaffController {
 	) {
 		List<UUID> responseDtoList = deliveryStaffService.getCompanyDeliveryStaffList(hubId);
 		return ResponseEntity.ok(responseDtoList);
+	}
+
+	@DeleteMapping("/{deliveryStaffId}")
+	public ResponseEntity<String> deleteDeliveryStaff(
+		@PathVariable UUID deliveryStaffId
+	) {
+		deliveryStaffService.deleteDeliveryStaff(deliveryStaffId);
+		return ResponseEntity.ok("삭제 완료");
 	}
 }

--- a/auth/src/main/java/com/example/auth/presentation/controller/DeliveryStaffController.java
+++ b/auth/src/main/java/com/example/auth/presentation/controller/DeliveryStaffController.java
@@ -1,0 +1,30 @@
+package com.example.auth.presentation.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.auth.application.service.DeliveryStaffService;
+import com.example.auth.presentation.dto.DeliveryStaffRegisterRequestDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/delivery-staff")
+public class DeliveryStaffController {
+
+	private final DeliveryStaffService deliveryStaffService;
+
+	@PostMapping("/register")
+	public ResponseEntity<String> registerDeliveryStaff(
+		@RequestBody @Valid DeliveryStaffRegisterRequestDto requestDto) {
+		deliveryStaffService.registerDeliveryStaff(requestDto);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body("배송 담당자 등록 완료");
+	}
+}

--- a/auth/src/main/java/com/example/auth/presentation/dto/DeliveryStaffRegisterRequestDto.java
+++ b/auth/src/main/java/com/example/auth/presentation/dto/DeliveryStaffRegisterRequestDto.java
@@ -1,0 +1,21 @@
+package com.example.auth.presentation.dto;
+
+import java.util.UUID;
+
+import com.example.auth.domain.model.enums.DeliveryType;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DeliveryStaffRegisterRequestDto(
+	@NotBlank
+	String username,
+	@NotNull
+	DeliveryType deliveryType,
+	@Email
+	String slackId,
+	UUID hubId
+
+) {
+}

--- a/delivery/src/main/java/com/example/delivery/infrastructure/client/DeliveryStaffClient.java
+++ b/delivery/src/main/java/com/example/delivery/infrastructure/client/DeliveryStaffClient.java
@@ -10,10 +10,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name = "auth")
 public interface DeliveryStaffClient {
 
-	@GetMapping("/delivery-staffs/hub")
+	@GetMapping("/api/delivery-staffs/hub")
 	List<UUID> getHubDeliveryStaffList();
 
-	@GetMapping("/delivery-staffs/{destinationHubId}")
-	List<UUID> getCompanyDeliveryStaffList(@PathVariable UUID destinationHubId);
+	@GetMapping("/api/delivery-staffs/{hubId}")
+	List<UUID> getCompanyDeliveryStaffList(@PathVariable UUID hubId);
 
 }

--- a/delivery/src/main/java/com/example/delivery/infrastructure/client/DeliveryStaffClient.java
+++ b/delivery/src/main/java/com/example/delivery/infrastructure/client/DeliveryStaffClient.java
@@ -7,10 +7,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "delivery-staff-service")
+@FeignClient(name = "auth")
 public interface DeliveryStaffClient {
 
-	@GetMapping("/delivery-staffs")
+	@GetMapping("/delivery-staffs/hub")
 	List<UUID> getHubDeliveryStaffList();
 
 	@GetMapping("/delivery-staffs/{destinationHubId}")

--- a/delivery/src/main/java/com/example/delivery/infrastructure/client/HubClient.java
+++ b/delivery/src/main/java/com/example/delivery/infrastructure/client/HubClient.java
@@ -14,7 +14,7 @@ import com.example.delivery.application.dto.HubResponse;
 @FeignClient(name = "hub")
 public interface HubClient {
 
-	@GetMapping("/{hubId}")
+	@GetMapping("/api/{hubId}")
 	ResponseEntity<HubResponse> getHub(@PathVariable UUID hubId);
 
 	@GetMapping

--- a/gateway/src/main/java/com/example/gateway/filter/CustomAuthenticationFilter.java
+++ b/gateway/src/main/java/com/example/gateway/filter/CustomAuthenticationFilter.java
@@ -27,7 +27,7 @@ public class CustomAuthenticationFilter implements GlobalFilter, Ordered {
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 
 		String path = exchange.getRequest().getURI().getPath();
-		if (path.contains("/api/auth/signUp") || path.contains("/api/auth/signIn")) {
+		if (path.contains("/api/auth/signUp") || path.contains("/api/auth/signIn") || path.contains("/api/delivery-staff/register")) {
 			return chain.filter(exchange);
 		}
 

--- a/gateway/src/main/java/com/example/gateway/filter/CustomAuthorizationFilter.java
+++ b/gateway/src/main/java/com/example/gateway/filter/CustomAuthorizationFilter.java
@@ -25,7 +25,7 @@ public class CustomAuthorizationFilter implements GlobalFilter, Ordered {
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		String path = exchange.getRequest().getURI().getPath();
 
-		if (path.contains("/api/auth/signUp") || path.contains("/api/auth/signIn")) {
+		if (path.contains("/api/auth/signUp") || path.contains("/api/auth/signIn") || path.contains("/api/delivery-staff/register")) {
 			return chain.filter(exchange);
 		}
 


### PR DESCRIPTION
#41 
#43 
#44 

삭제는 enum에 상태를 추가하여 관리할 수 있도록 하였습니다.
이를 통해 jpa 쿼리 조회시 이넘값을 사용하면 자동으로 삭제된 데이터는 거를 수 있도록 하였습니다.
(예를 들어, 허브배송담당자 조회 시  업체배송담당자와 비활성화된 배송담당자는 제외됨)

pr이 꼬여서 게이트웨이는 머지했습니다  궁금하시면 요약만 보셔도 됩니다..!